### PR TITLE
Add instrumentation for Rails apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## master
 
+- Added ActiveSupport-based instrumentation. ([@palkan][])
+
+  See [PR#4](https://github.com/palkan/action_policy/pull/4)
+
 - Allow passing authorization context explicitly. ([@palkan][])
 
   Closes [#3](https://github.com/palkan/action_policy/issues/3).

--- a/docs/instrumentation.md
+++ b/docs/instrumentation.md
@@ -37,15 +37,25 @@ end
 
 ### `action_policy.authorize`
 
-This event is identitical to `action_policy.apply_rule` with the one difference:
+This event is identical to `action_policy.apply_rule` with the one difference:
 **it's only triggered when `authorize!` method is called**.
 
 The motivation behind having a separate event for this method is to monitor the number of failed
-authorizations: the very high number of failed authorization usually means that we do not take
-into account authorization rules in the application UI (e.g. we show a "Delete" button to the user not
+authorizations: the high number of failed authorizations usually means that we do not take
+into account authorization rules in the application UI (e.g., we show a "Delete" button to the user not
 permitted to do that).
 
 The `action_policy.apply_rule` might have a large number of failures, 'cause it also tracks the usage of non-raising applications (i.e. `allowed_to?`).
+
+## Turn off instrumentation
+
+Instrumentation is enabled by default. To turn it off add to your configuration:
+
+```ruby
+config.action_policy.instrumentation_enabled = false
+```
+
+**NOTE:** changing this setting after the application has been initialized doesn't take any effect.
 
 ## Non-Rails usage
 

--- a/lib/action_policy/authorizer.rb
+++ b/lib/action_policy/authorizer.rb
@@ -20,8 +20,12 @@ module ActionPolicy
     class << self
       # Performs authorization, raises an exception when check failed.
       def call(policy, rule)
-        policy.apply(rule) ||
+        authorize(policy, rule) ||
           raise(::ActionPolicy::Unauthorized.new(policy, rule))
+      end
+
+      def authorize(policy, rule)
+        policy.apply(rule)
       end
 
       # Applies scope to the target

--- a/lib/action_policy/policy/cache.rb
+++ b/lib/action_policy/policy/cache.rb
@@ -42,7 +42,10 @@ module ActionPolicy # :nodoc:
 
         ActionPolicy.cache_store.then do |store|
           @result = store.read(key)
-          next result.value unless result.nil?
+          unless result.nil?
+            result.cached!
+            next result.value
+          end
           yield
           store.write(key, result, options)
           result.value

--- a/lib/action_policy/policy/core.rb
+++ b/lib/action_policy/policy/core.rb
@@ -65,7 +65,7 @@ module ActionPolicy
 
       attr_reader :record, :result
 
-      def initialize(record = nil)
+      def initialize(record = nil, **_opts)
         @record = record
       end
 

--- a/lib/action_policy/policy/execution_result.rb
+++ b/lib/action_policy/policy/execution_result.rb
@@ -27,6 +27,14 @@ module ActionPolicy
         @value == false
       end
 
+      def cached!
+        @cached = true
+      end
+
+      def cached?
+        @cached == true
+      end
+
       def inspect
         "<#{policy}##{rule}: #{@value}>"
       end

--- a/lib/action_policy/rails/authorizer.rb
+++ b/lib/action_policy/rails/authorizer.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module ActionPolicy # :nodoc:
+  module Rails
+    # Add instrumentation for `authorize!` method
+    module Authorizer
+      EVENT_NAME = "action_policy.authorize"
+
+      def authorize(policy, rule)
+        event = {policy: policy.class.name, rule: rule.to_s}
+        ActiveSupport::Notifications.instrument(EVENT_NAME, event) do
+          res = super
+          event[:cached] = policy.result.cached?
+          event[:value] = policy.result.value
+          res
+        end
+      end
+    end
+  end
+end

--- a/lib/action_policy/rails/policy/instrumentation.rb
+++ b/lib/action_policy/rails/policy/instrumentation.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module ActionPolicy # :nodoc:
+  module Policy
+    module Rails
+      # Add ActiveSupport::Notifications support.
+      #
+      # Fires `action_policy.apply` event on every `#apply` call.
+      module Instrumentation
+        EVENT_NAME = "action_policy.apply"
+
+        def apply(rule)
+          event = {policy: self.class.name, rule: rule.to_s}
+          ActiveSupport::Notifications.instrument(EVENT_NAME, event) do
+            res = super
+            event[:cached] = result.cached?
+            event[:value] = result.value
+            res
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/action_policy/rails/policy/instrumentation.rb
+++ b/lib/action_policy/rails/policy/instrumentation.rb
@@ -5,9 +5,9 @@ module ActionPolicy # :nodoc:
     module Rails
       # Add ActiveSupport::Notifications support.
       #
-      # Fires `action_policy.apply` event on every `#apply` call.
+      # Fires `action_policy.apply_rule` event on every `#apply` call.
       module Instrumentation
-        EVENT_NAME = "action_policy.apply"
+        EVENT_NAME = "action_policy.apply_rule"
 
         def apply(rule)
           event = {policy: self.class.name, rule: rule.to_s}

--- a/lib/action_policy/railtie.rb
+++ b/lib/action_policy/railtie.rb
@@ -61,6 +61,12 @@ module ActionPolicy # :nodoc:
       end
     end
 
+    initializer "action_policy.instrumentation" do |_app|
+      require "action_policy/rails/policy/instrumentation"
+
+      ActionPolicy::Base.include ActionPolicy::Policy::Rails::Instrumentation
+    end
+
     config.to_prepare do |_app|
       ActionPolicy::LookupChain.namespace_cache_enabled =
         Rails.application.config.action_policy.namespace_cache_enabled

--- a/test/action_policy/policy/cache_test.rb
+++ b/test/action_policy/policy/cache_test.rb
@@ -2,29 +2,7 @@
 
 require "test_helper"
 
-class InMemoryCache
-  attr_accessor :store
-
-  def initialize
-    self.store = {}
-  end
-
-  def read(key)
-    deserialize(store[key]) if store.key?(key)
-  end
-
-  def write(key, val, _options)
-    store[key] = serialize(val)
-  end
-
-  def serialize(val)
-    Marshal.dump(val)
-  end
-
-  def deserialize(val)
-    Marshal.load(val)
-  end
-end
+require "stubs/in_memory_cache"
 
 class TestCache < Minitest::Test
   class TestPolicy

--- a/test/action_policy/rails/instrumentation_test.rb
+++ b/test/action_policy/rails/instrumentation_test.rb
@@ -13,7 +13,7 @@ class TestRailsInstrumentation < Minitest::Test
   class TestPolicy
     include ActionPolicy::Policy::Core
     include ActionPolicy::Policy::Cache
-    include ActionPolicy::Policy::Rails::Instrumentation
+    prepend ActionPolicy::Policy::Rails::Instrumentation
 
     cache :manage?
 

--- a/test/action_policy/rails/policy/instrumentation_test.rb
+++ b/test/action_policy/rails/policy/instrumentation_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "active_support"
+require "action_policy/rails/policy/instrumentation"
+
+class TestRailsInstrumentation < Minitest::Test
+  class TestPolicy
+    include ActionPolicy::Policy::Core
+    include ActionPolicy::Policy::Cache
+    include ActionPolicy::Policy::Rails::Instrumentation
+
+    cache :manage?
+
+    def manage?
+      true
+    end
+
+    def show?
+      false || record
+    end
+
+    def authorization_context
+      {}
+    end
+  end
+
+  def setup
+    ActionPolicy.cache_store = InMemoryCache.new
+    @events = []
+
+    ActiveSupport::Notifications.subscribe(/action_policy\./) do |event, *, data|
+      @events << [event, data]
+    end
+  end
+
+  def teardown
+    ActionPolicy.cache_store = nil
+  end
+
+  attr_reader :events
+
+  def test_instrument_apply
+    policy = TestPolicy.new false
+
+    refute policy.apply(:show?)
+
+    assert_equal 1, events.size
+
+    event, data = events.pop
+
+    assert_equal "action_policy.apply", event
+    assert_equal TestPolicy.name, data[:policy]
+    assert_equal "show?", data[:rule]
+    refute data[:cached]
+  end
+
+  def test_instrument_cached_apply
+    policy = TestPolicy.new true
+
+    assert policy.apply(:manage?)
+
+    assert_equal 1, events.size
+
+    event, data = events.pop
+
+    assert_equal "action_policy.apply", event
+    assert_equal TestPolicy.name, data[:policy]
+    assert_equal "manage?", data[:rule]
+    assert_equal false, data[:cached]
+
+    assert policy.apply(:manage?)
+
+    assert_equal 1, events.size
+
+    _event_2, data_2 = events.pop
+
+    assert_equal true, data_2[:cached]
+  end
+end

--- a/test/stubs/in_memory_cache.rb
+++ b/test/stubs/in_memory_cache.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class InMemoryCache
+  attr_accessor :store
+
+  def initialize
+    self.store = {}
+  end
+
+  def read(key)
+    deserialize(store[key]) if store.key?(key)
+  end
+
+  def write(key, val, _options)
+    store[key] = serialize(val)
+  end
+
+  def serialize(val)
+    Marshal.dump(val)
+  end
+
+  def deserialize(val)
+    Marshal.load(val)
+  end
+end


### PR DESCRIPTION
### What is the purpose of this pull request?

This PR adds instrumentation support (`ActiveSupport::Notifications`-based).

PR checklist:

- [x] `"action_policy.apply"` event
- [x] `"action_policy.authorize"` event
- [x] Documentation updated
- [x] Changelog entry added