### PR TITLE
Change the base modules order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## master
+- Fix modules order in `ActionPolicy::Base`. ([@ilyasgaraev][])
 
 ## 0.1.2 (2018-05-09)
 
@@ -13,3 +14,4 @@
 - Initial pre-release version. ([@palkan][])
 
 [@palkan]: https://github.com/palkan
+[@ilyasgaraev]: https://github.com/ilyasgaraev

--- a/lib/action_policy/base.rb
+++ b/lib/action_policy/base.rb
@@ -14,8 +14,8 @@ module ActionPolicy
 
     include ActionPolicy::Policy::Core
     include ActionPolicy::Policy::Authorization
-    include ActionPolicy::Policy::Reasons
     include ActionPolicy::Policy::PreCheck
+    include ActionPolicy::Policy::Reasons
     include ActionPolicy::Policy::Aliases
     include ActionPolicy::Policy::Cache
     include ActionPolicy::Policy::CachedApply


### PR DESCRIPTION
### What is the purpose of this pull request?
Fix the modules order in `ActionPolicy::Base`.

### What changes did you make? (overview)
When we apply the rule, we are calling all `apply` methods from the modules. If the user sets `pre_check` in `ApplicationPolicy` and this method returns `deny!`, `ApplicationPolicy` raises an exception:

```ruby
NoMethodError (undefined method `add' for nil:NilClass)
```

Code example:

```
class ApplicationPolicy < ActionPolicy::Base
  pre_check :allowed_for_user

  private

  def allowed_for_user
    deny!
  end
end
```

The main reason for this error is that `reasons` in policy is nil:
https://github.com/palkan/action_policy/blob/becc4f9238458696ae9f406e38e3c903e5765655/lib/action_policy/policy/pre_check.rb#L86

This is because the `PreCheck#apply` method calls **before** `Reasons#apply` and `reasons` is not initialized.

My fix changes modules order and the `PreCheck#apply` method calls **after** `Reasons#apply`, therefore `reasons` is initialized and equal to `FailureReasons.new`.

I think that my changes cannot be covered by any tests. Please correct me if I'm wrong. But we can reproduce the error in the test. Just need to include `ActionPolicy::Policy::Reasons` module before `ActionPolicy::Policy::PreCheck` in this class:

https://github.com/palkan/action_policy/blob/becc4f9238458696ae9f406e38e3c903e5765655/test/action_policy/policy/pre_check_test.rb#L9

### Is there anything you'd like reviewers to focus on?
N/A

PR checklist:

- [ ] Tests included
- [ ] Documentation updated
- [x] Changelog entry added
