### PR TITLE
Fix link to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Action Policy is an authorization framework for Ruby and Rails applications.
 
-📑 [Documentation][https://actionpolicy.evilmartians.io]
+📑 [Documentation](https://actionpolicy.evilmartians.io)
 
 <a href="https://evilmartians.com/?utm_source=action_policy">
 <img src="https://evilmartians.com/badges/sponsored-by-evil-martians.svg" alt="Sponsored by Evil Martians" width="236" height="54"></a>


### PR DESCRIPTION
Just a typo fix/minor documentation update.

Thanks for your work on this gem!