### PR TITLE
Fix alias lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 ## master
 
+- [Fix [#18](https://github.com/palkan/action_policy/issues/18)] Clarify documentation around, and fix the way `resolve_rule` resolves rules and rule aliases when subclasses are involved. ([@brendon][])
+
 ## 0.2.1 (2018-06-28)
 
 - Use `send` instead of `public_send` to get the `authorization_context` so that contexts such as
   `current_user` can be `private` in the controller. ([@brendon][])
 
 - Fix railtie initialisation for Rails < 5. ([@brendon][])
-
 
 ## 0.2.0 (2018-06-17)
 

--- a/docs/aliases.md
+++ b/docs/aliases.md
@@ -52,3 +52,59 @@ end
 Now when you call `authorize! post` with any rule not explicitly defined in policy class, the `manage?` rule is applied.
 
 By default, `ActionPolicy::Base` sets `manage?` as a default rule.
+
+## Rule resolution with subclasses
+
+Here's the order in which aliases and concrete rule methods are resolved in regards to subclasses:
+
+1. If there is a concrete rule method on the subclass, this is called, else
+2. If there is a matching alias then this is called, else
+  * When aliases are defined on the subclass they will overwrite matching aliases on the superclass.
+3. If there is a concrete rule method on the superclass, then this is called, else
+4. If there is a default rule defined, then this is called, else
+5. `ActionPolicy::UnknownRule` is raised.
+
+Here's an example with the expected results:
+
+```ruby
+class SuperPolicy < ApplicationPolicy
+  default_rule :manage?
+
+  alias_rule :update?, :destroy?, :create?, to: :edit?
+
+  def manage?; end
+
+  def edit?; end
+
+  def index?; end
+end
+
+class SubPolicy < AbstractPolicy
+  default_rule nil
+
+  alias_rule :index?, :update?, to: :manage?
+
+  def create?; end
+end
+```
+
+Authorizing against the SuperPolicy:
+
+* `update?` will resolve to `edit?`
+* `destroy?` will resolve to `edit?`
+* `create?` will resolve to `edit?`
+* `manage?` will resolve to `manage?`
+* `edit?` will resolve to `edit?`
+* `index?` will resolve to `index?`
+* `something?` will resolve to `manage?`
+
+Authorizing against the SuBPolicy:
+
+* `index?` will resolve to `manage?`
+* `update?` will resolve to `manage?`
+* `create?` will resolve to `create?`
+* `destroy?` will resolve to `edit?`
+* `manage?` will resolve to `manage?`
+* `edit?` will resolve to `edit?`
+* `index?` will resolve to `manage?`
+* `something?` will raise `ActionPolicy::UnknownRule`

--- a/docs/aliases.md
+++ b/docs/aliases.md
@@ -53,6 +53,10 @@ Now when you call `authorize! post` with any rule not explicitly defined in poli
 
 By default, `ActionPolicy::Base` sets `manage?` as a default rule.
 
+## Aliases and Private Methods
+
+Rules in `action_policy` can only be public methods. Trying to use a private method as a rule will raise an error. Thus, aliases can also only point to public methods.
+
 ## Rule resolution with subclasses
 
 Here's the order in which aliases and concrete rule methods are resolved in regards to subclasses:

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -36,6 +36,8 @@ end
 
 **NOTE:** it is not necessary to inherit from `ActionPolicy::Base`; instead, you can [construct basic policy](custom_policy.md) choosing only the components you need.
 
+Rules must be public methods on the class. Using private methods as rules will raise an error.
+
 Consider a simple example:
 
 ```ruby

--- a/lib/action_policy/policy/aliases.rb
+++ b/lib/action_policy/policy/aliases.rb
@@ -29,15 +29,10 @@ module ActionPolicy
       end
 
       def resolve_rule(activity)
-        if self.class.instance_methods(false).include?(activity)
-          activity
-        elsif self.class.lookup_alias(activity)
-          self.class.lookup_alias(activity)
-        elsif self.class.superclass.instance_methods.include?(activity)
-          activity
-        else
-          self.class.lookup_default_rule || super
-        end
+        self.class.lookup_alias(activity) ||
+          (activity if respond_to?(activity)) ||
+          self.class.lookup_default_rule ||
+          super
       end
 
       module ClassMethods # :nodoc:
@@ -68,6 +63,10 @@ module ActionPolicy
             else
               {}
             end
+        end
+
+        def method_added(name)
+          rules_aliases.delete(name)
         end
       end
     end

--- a/lib/action_policy/policy/aliases.rb
+++ b/lib/action_policy/policy/aliases.rb
@@ -29,8 +29,15 @@ module ActionPolicy
       end
 
       def resolve_rule(activity)
-        return activity if respond_to?(activity)
-        self.class.lookup_alias(activity) || super
+        if self.class.instance_methods(false).include?(activity)
+          activity
+        elsif self.class.lookup_alias(activity)
+          self.class.lookup_alias(activity)
+        elsif self.class.superclass.instance_methods.include?(activity)
+          activity
+        else
+          self.class.lookup_default_rule || super
+        end
       end
 
       module ClassMethods # :nodoc:
@@ -45,7 +52,11 @@ module ActionPolicy
         end
 
         def lookup_alias(rule)
-          rules_aliases.fetch(rule, rules_aliases[DEFAULT])
+          rules_aliases[rule]
+        end
+
+        def lookup_default_rule
+          rules_aliases[DEFAULT]
         end
 
         def rules_aliases

--- a/lib/action_policy/policy/aliases.rb
+++ b/lib/action_policy/policy/aliases.rb
@@ -66,7 +66,7 @@ module ActionPolicy
         end
 
         def method_added(name)
-          rules_aliases.delete(name)
+          rules_aliases.delete(name) if public_method_defined?(name)
         end
       end
     end

--- a/test/action_policy/policy/aliases_test.rb
+++ b/test/action_policy/policy/aliases_test.rb
@@ -8,7 +8,7 @@ class AliasesRuleTestPolicy
 
   default_rule :manage?
 
-  alias_rule :update?, :destroy?, to: :edit?
+  alias_rule :update?, :destroy?, :create?, to: :edit?
 
   def manage?; end
 
@@ -20,6 +20,8 @@ class AliasesRuleTestPolicy
     default_rule nil
 
     alias_rule :index?, :update?, to: :manage?
+
+    def create?; end
   end
 end
 
@@ -57,5 +59,6 @@ class TestPolicyAliasesRule < Minitest::Test
     assert_equal :edit?, policy.resolve_rule(:destroy?)
     assert_equal :manage?, policy.resolve_rule(:update?)
     assert_equal :manage?, policy.resolve_rule(:index?)
+    assert_equal :create?, policy.resolve_rule(:create?)
   end
 end

--- a/test/action_policy/policy/aliases_test.rb
+++ b/test/action_policy/policy/aliases_test.rb
@@ -14,10 +14,12 @@ class AliasesRuleTestPolicy
 
   def edit?; end
 
+  def index?; end
+
   class NoDefault < self
     default_rule nil
 
-    alias_rule :update?, to: :manage?
+    alias_rule :index?, :update?, to: :manage?
   end
 end
 
@@ -54,5 +56,6 @@ class TestPolicyAliasesRule < Minitest::Test
 
     assert_equal :edit?, policy.resolve_rule(:destroy?)
     assert_equal :manage?, policy.resolve_rule(:update?)
+    assert_equal :manage?, policy.resolve_rule(:index?)
   end
 end


### PR DESCRIPTION
Fixes #18

### What is the purpose of this pull request?
The rule lookup process with respect to aliases was flawed as it gave precedence to existing methods in ancestors before looking up aliases. This meant that one couldn't override an existing method on an ancestor with an alias to another method in the subclass.

### What changes did you make? (overview)
Modified the rule lookup process:
1. Look only at the methods of this class for the rule first.
2. If not found, look at the rules_aliases for a match, return matched alias target if found.
3. If not found, look at superclass (and ancestors) methods for a match.
4. If not found, look for the default rule.
5. If not found, call super to raise an error.

### Is there anything you'd like reviewers to focus on?
Coding style and perhaps oversights in logic.

PR checklist:

- [x] Tests included
- [x] Documentation updated
- [x] Changelog entry added