### PR TITLE
Fix initialisation for Rails < 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+- Fix railtie initialisation for Rails < 5. ([@brendon][])
+
 ## 0.2.0 (2018-06-17)
 
 - Make `action_policy` JRuby-compatible. ([@palkan][])

--- a/lib/action_policy/cache_middleware.rb
+++ b/lib/action_policy/cache_middleware.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 module ActionPolicy # :nodoc:
-  class Middleware # :nodoc:
+  class CacheMiddleware # :nodoc:
     def initialize(app)
       @app = app
     end
 
     def call(env)
       ActionPolicy::PerThreadCache.clear_all
-      status, headers, response = @app.call(env)
+      result = @app.call(env)
       ActionPolicy::PerThreadCache.clear_all
 
-      [status, headers, response]
+      result
     end
   end
 end

--- a/lib/action_policy/middleware.rb
+++ b/lib/action_policy/middleware.rb
@@ -1,15 +1,17 @@
-module ActionPolicy
-	class Middleware
-		def initialize app
-	    @app = app
-	  end
+# frozen_string_literal: true
 
-	  def call(env)
-	  	ActionPolicy::PerThreadCache.clear_all
-	  	status, headers, response = @app.call(env)
-	  	ActionPolicy::PerThreadCache.clear_all
+module ActionPolicy # :nodoc:
+  class Middleware # :nodoc:
+    def initialize(app)
+      @app = app
+    end
 
-	  	[status, headers, response]
-	  end
-	end
+    def call(env)
+      ActionPolicy::PerThreadCache.clear_all
+      status, headers, response = @app.call(env)
+      ActionPolicy::PerThreadCache.clear_all
+
+      [status, headers, response]
+    end
+  end
 end

--- a/lib/action_policy/middleware.rb
+++ b/lib/action_policy/middleware.rb
@@ -1,0 +1,15 @@
+module ActionPolicy
+	class Middleware
+		def initialize app
+	    @app = app
+	  end
+
+	  def call(env)
+	  	ActionPolicy::PerThreadCache.clear_all
+	  	status, headers, response = @app.call(env)
+	  	ActionPolicy::PerThreadCache.clear_all
+
+	  	[status, headers, response]
+	  end
+	end
+end

--- a/lib/action_policy/railtie.rb
+++ b/lib/action_policy/railtie.rb
@@ -3,6 +3,7 @@
 module ActionPolicy # :nodoc:
   require "action_policy/rails/controller"
   require "action_policy/rails/channel"
+  require "action_policy/middleware"
 
   class Railtie < ::Rails::Railtie # :nodoc:
     # Provides Rails-specific configuration,

--- a/lib/action_policy/railtie.rb
+++ b/lib/action_policy/railtie.rb
@@ -50,7 +50,7 @@ module ActionPolicy # :nodoc:
         app.executor.to_run { ActionPolicy::PerThreadCache.clear_all }
         app.executor.to_complete { ActionPolicy::PerThreadCache.clear_all }
       else
-        app.middleware.use ActionPolicy::Middleware
+        app_middleware.use ActionPolicy::CacheMiddleware
       end
     end
 

--- a/lib/action_policy/railtie.rb
+++ b/lib/action_policy/railtie.rb
@@ -45,8 +45,12 @@ module ActionPolicy # :nodoc:
     config.action_policy = Config
 
     initializer "action_policy.clear_per_thread_cache" do |app|
-      app.executor.to_run { ActionPolicy::PerThreadCache.clear_all }
-      app.executor.to_complete { ActionPolicy::PerThreadCache.clear_all }
+      if Rails::VERSION::MAJOR >= 5
+        app.executor.to_run { ActionPolicy::PerThreadCache.clear_all }
+        app.executor.to_complete { ActionPolicy::PerThreadCache.clear_all }
+      else
+        app.middleware.use ActionPolicy::Middleware
+      end
     end
 
     config.to_prepare do |_app|


### PR DESCRIPTION
Fixes #19

### What is the purpose of this pull request?
Fixes the initialisation of `action_policy` on Rails < 5 by moving the cache clearing into a Rack Middleware wrapping the request cycle.

### What changes did you make? (overview)
Added a code branch based on the rails version and replicated the thread clearing 'callbacks' in a Middleware that will be used if one is using Rails < 5.

### Is there anything you'd like reviewers to focus on?
I added no tests because you mentioned there were no tests on the railtie anyway. Feel free to add some but I'm not sure where to start. Perhaps an integration test to make sure caching works as expected and is cleared per-request?

-->

PR checklist:

- [ ] Tests included
- [x] Changelog entry added