### PR TITLE
Fix middleware loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+- Fix the broken middleware require statement and reference to app_middleware. ([@brendon][])
+
 ## 0.2.1 (2018-06-28)
 
 - Use `send` instead of `public_send` to get the `authorization_context` so that contexts such as

--- a/lib/action_policy/railtie.rb
+++ b/lib/action_policy/railtie.rb
@@ -50,7 +50,7 @@ module ActionPolicy # :nodoc:
         app.executor.to_run { ActionPolicy::PerThreadCache.clear_all }
         app.executor.to_complete { ActionPolicy::PerThreadCache.clear_all }
       else
-        app_middleware.use ActionPolicy::CacheMiddleware
+        app.middleware.use ActionPolicy::CacheMiddleware
       end
     end
 

--- a/lib/action_policy/railtie.rb
+++ b/lib/action_policy/railtie.rb
@@ -3,7 +3,7 @@
 module ActionPolicy # :nodoc:
   require "action_policy/rails/controller"
   require "action_policy/rails/channel"
-  require "action_policy/middleware"
+  require "action_policy/cache_middleware"
 
   class Railtie < ::Rails::Railtie # :nodoc:
     # Provides Rails-specific configuration,


### PR DESCRIPTION
I forgot to update the `require` statement when updating the name of the middleware.

Also app_middleware isn't a method in this context so we need to use app.middleware.

- [x] Changelog entry added