### PR TITLE
Fix broken authorization_context link in non_rails.md

### DIFF
--- a/docs/non_rails.md
+++ b/docs/non_rails.md
@@ -26,4 +26,4 @@ class PostUpdateAction
 end
 ```
 
-`ActionPolicy::Behaviour` provides `authorize` class-level method to configure [authorization context](authorization_context.rb) and two instance-level methods: `authorize!` and `allowed_to?`.
+`ActionPolicy::Behaviour` provides `authorize` class-level method to configure [authorization context](authorization_context.md) and two instance-level methods: `authorize!` and `allowed_to?`.


### PR DESCRIPTION
I discovered this gem and was reading the documentation when I found this broken link, so here's a PR to fix it