### PR TITLE
Add scoping testing

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -157,3 +157,26 @@ end
 You can also specify `as` option.
 
 **NOTE:** both `type` and `with` params are required.
+
+### RSpec
+
+Add the following to your `rails_helper.rb` (or `spec_helper.rb`):
+
+```ruby
+require "action_policy/rspec"
+```
+
+Now you can use `have_authorized_scope` matcher:
+
+```ruby
+describe UsersController do
+  subject { get :index }
+
+  it "has authorized scope" do
+    expect { subject }.to have_authorized_scope(:active_record_relation)
+      .with(PostPolicy)
+  end
+end
+```
+
+You can also add `.as(:named_scope)` option.

--- a/lib/action_policy.rb
+++ b/lib/action_policy.rb
@@ -20,7 +20,6 @@ module ActionPolicy
   require "action_policy/version"
   require "action_policy/base"
   require "action_policy/lookup_chain"
-  require "action_policy/authorizer"
   require "action_policy/behaviour"
 
   class << self

--- a/lib/action_policy/authorizer.rb
+++ b/lib/action_policy/authorizer.rb
@@ -14,15 +14,19 @@ module ActionPolicy
     end
   end
 
-  # Performs authorization, raises an exception when check failed.
-  #
-  # The main purpose of this module is to extact authorize action
+  # The main purpose of this module is to extact authorize actions
   # from everything else to make it easily testable.
   module Authorizer
     class << self
+      # Performs authorization, raises an exception when check failed.
       def call(policy, rule)
         policy.apply(rule) ||
           raise(::ActionPolicy::Unauthorized.new(policy, rule))
+      end
+
+      # Applies scope to the target
+      def scopify(target, policy, **options)
+        policy.apply_scope(target, **options)
       end
     end
   end

--- a/lib/action_policy/behaviour.rb
+++ b/lib/action_policy/behaviour.rb
@@ -59,13 +59,13 @@ module ActionPolicy
     #   - first, check whether `with` option is present
     #   - secondly, try to infer policy class from `target` (non-raising lookup)
     #   - use `implicit_authorization_target` if none of the above works.
-    def authorized(target, type: nil, as: :default, with: nil, **options)
-      policy = with || policy_for(record: target, allow_nil: true, **options)
+    def authorized(target, type: nil, as: :default, **options)
+      policy = policy_for(record: target, allow_nil: true, **options)
       policy ||= policy_for(record: implicit_authorization_target, **options)
 
       type ||= authorization_scope_type_for(policy, target)
 
-      Authorizer.scopify(target, policy, type: type, name: as, **options)
+      Authorizer.scopify(target, policy, type: type, name: as)
     end
 
     def authorization_context

--- a/lib/action_policy/behaviour.rb
+++ b/lib/action_policy/behaviour.rb
@@ -5,6 +5,8 @@ require "action_policy/behaviours/memoized"
 require "action_policy/behaviours/thread_memoized"
 require "action_policy/behaviours/namespaced"
 
+require "action_policy/authorizer"
+
 module ActionPolicy
   # Provides `authorize!` and `allowed_to?` methods and
   # `authorize` class method to define authorization context.
@@ -63,7 +65,7 @@ module ActionPolicy
 
       type ||= authorization_scope_type_for(policy, target)
 
-      policy.apply_scope(target, type: type, name: as)
+      Authorizer.scopify(target, policy, type: type, name: as, **options)
     end
 
     def authorization_context

--- a/lib/action_policy/behaviour.rb
+++ b/lib/action_policy/behaviour.rb
@@ -60,6 +60,9 @@ module ActionPolicy
     def authorized(target, type: nil, as: :default, with: nil, **options)
       policy = with || policy_for(record: target, allow_nil: true, **options)
       policy ||= policy_for(record: implicit_authorization_target, **options)
+
+      type ||= authorization_scope_type_for(policy, target)
+
       policy.apply_scope(target, type: type, name: as)
     end
 
@@ -77,6 +80,12 @@ module ActionPolicy
     # otherwise fallback to :manage? rule.
     def authorization_rule_for(policy, rule)
       policy.resolve_rule(rule)
+    end
+
+    # Infer scope type for target if none provided.
+    # Raises an exception if type couldn't be inferred.
+    def authorization_scope_type_for(policy, target)
+      policy.resolve_scope_type(target)
     end
 
     # Override this method to provide implicit authorization target

--- a/lib/action_policy/policy/scoping.rb
+++ b/lib/action_policy/policy/scoping.rb
@@ -89,11 +89,7 @@ module ActionPolicy
       # If `name` is not specified then `:default` name is used.
       # If `type` is not specified then we try to infer the type from the
       # target class.
-      def apply_scope(target, type: nil, name: :default)
-        type = lookup_type_from_target(target) if type.nil?
-
-        raise ActionPolicy::UnrecognizedScopeTarget, target if type.nil?
-
+      def apply_scope(target, type:, name: :default)
         raise ActionPolicy::UnknownScopeType.new(self.class, type) unless
           self.class.scoping_handlers.key?(type)
 
@@ -101,6 +97,11 @@ module ActionPolicy
           self.class.scoping_handlers[type].key?(name)
 
         send(:"__scoping__#{type}__#{name}", target)
+      end
+
+      def resolve_scope_type(target)
+        lookup_type_from_target(target) ||
+          raise(ActionPolicy::UnrecognizedScopeTarget, target)
       end
 
       def lookup_type_from_target(target)

--- a/lib/action_policy/rspec.rb
+++ b/lib/action_policy/rspec.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 require "action_policy/rspec/be_authorized_to"
+require "action_policy/rspec/have_authorized_scope"

--- a/lib/action_policy/rspec/have_authorized_scope.rb
+++ b/lib/action_policy/rspec/have_authorized_scope.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "action_policy/testing"
+
+module ActionPolicy
+  module RSpec
+    # Implements `have_authorized_scope` matcher.
+    #
+    # Verifies that a block of code applies authorization scoping using specific policy.
+    #
+    # Example:
+    #
+    #   # in controller/request specs
+    #   subject { get :index }
+    #
+    #   it "has authorized scope" do
+    #     expect { subject }
+    #       .to have_authorized_scope(:active_record_relation)
+    #       .with(ProductPolicy)
+    #   end
+    #
+    class HaveAuthorizedScope < ::RSpec::Matchers::BuiltIn::BaseMatcher
+      attr_reader :type, :name, :policy, :actual_scopes
+
+      def initialize(type)
+        @type = type
+        @name = :default
+      end
+
+      def with(policy)
+        @policy = policy
+        self
+      end
+
+      def as(name)
+        @name = name
+        self
+      end
+
+      def match(_expected, actual)
+        raise "This matcher only supports block expectations" unless actual.is_a?(Proc)
+
+        ActionPolicy::Testing::AuthorizeTracker.tracking { actual.call }
+
+        @actual_scopes = ActionPolicy::Testing::AuthorizeTracker.scopings
+
+        actual_scopes.any? { |scope| scope.matches?(policy, type, name) }
+      end
+
+      def does_not_match?(*)
+        raise "This matcher doesn't support negation"
+      end
+
+      def supports_block_expectations?
+        true
+      end
+
+      def failure_message
+        "expected a scoping named :#{name} for type :#{type} " \
+        "from #{policy} to have been applied, " \
+        "but #{actual_scopes_message}"
+      end
+
+      def actual_scopes_message
+        if actual_scopes.empty?
+          "no scopings have been made"
+        else
+          "the following scopings were encountered:\n" \
+          "#{formatted_scopings}"
+        end
+      end
+
+      def formatted_scopings
+        actual_scopes.map do |ascope|
+          " - #{ascope.inspect}"
+        end.join("\n")
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include(Module.new do
+    def have_authorized_scope(type) # rubocop:disable Naming/PredicateName
+      ActionPolicy::RSpec::HaveAuthorizedScope.new(type)
+    end
+  end)
+end

--- a/lib/action_policy/test_helper.rb
+++ b/lib/action_policy/test_helper.rb
@@ -42,5 +42,37 @@ module ActionPolicy
       )
     end
     # rubocop: enable Metrics/MethodLength
+
+    # Asserts that the given policy was used for scoping.
+    #
+    #   def test_authorize
+    #     assert_have_authorized_scope(type: :active_record_relation, with: UserPolicy) do
+    #       get :index
+    #     end
+    #   end
+    #
+    # You can also specify `as` option.
+    #
+    # NOTE: `type` and `with` must be specified.
+    #
+    # rubocop: disable Metrics/MethodLength
+    def assert_have_authorized_scope(type:, with:, as: :default)
+      raise ArgumentError, "Block is required" unless block_given?
+
+      policy = with
+
+      ActionPolicy::Testing::AuthorizeTracker.tracking { yield }
+
+      actual_scopes = ActionPolicy::Testing::AuthorizeTracker.scopings
+
+      assert(
+        actual_scopes.any? { |scope| scope.matches?(policy, type, as) },
+        "Expected a scoping named :#{as} for :#{type} type from #{policy} to have been applied, " \
+        "but no such scoping has been made.\n" \
+        "Registered scopings: " \
+        "#{actual_scopes.empty? ? 'none' : actual_scopes.map(&:inspect).join(',')}"
+      )
+    end
+    # rubocop: enable Metrics/MethodLength
   end
 end

--- a/spec/action_policy/rspec_spec.rb
+++ b/spec/action_policy/rspec_spec.rb
@@ -39,110 +39,168 @@ class TestService # :nodoc:
     user = User.new(name)
     allowed_to?(:talk?, user)
   end
+
+  def filter(users)
+    authorized users, type: :data, with: CustomPolicy
+  end
+
+  def own(users)
+    authorized users, type: :data, as: :own, with: UserPolicy
+  end
 end
 
 describe "ActionPolicy RSpec matchers" do
   subject { TestService.new("guest") }
 
-  let(:target) { User.new("admin") }
+  describe "#be_authorized_to" do
+    let(:target) { User.new("admin") }
 
-  context "when authorization is performed" do
-    context "when target is specified" do
-      specify do
-        expect { subject.talk("admin") }
-          .to be_authorized_to(:manage?, target).with(UserPolicy)
+    context "when authorization is performed" do
+      context "when target is specified" do
+        specify do
+          expect { subject.talk("admin") }
+            .to be_authorized_to(:manage?, target).with(UserPolicy)
+        end
       end
-    end
 
-    context "when policy is not specified" do
-      specify do
-        expect { subject.talk("admin") }
-          .to be_authorized_to(:manage?, target)
-      end
-    end
-
-    context "with fallback rule" do
-      specify do
-        expect { subject.say("admin") }
-          .to be_authorized_to(:manage?, target).with(TestService::CustomPolicy)
-      end
-    end
-  end
-
-  context "when authorization hasn't been performed" do
-    context "when target doesn't match" do
-      specify do
-        expect do
-          expect { subject.talk("adminos") }
-            .to be_authorized_to(:update?, target)
-        end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
-      end
-    end
-
-    context "when implicit policy doesn't match" do
-      specify do
-        expect do
-          expect { subject.say("adminos") }
+      context "when policy is not specified" do
+        specify do
+          expect { subject.talk("admin") }
             .to be_authorized_to(:manage?, target)
-        end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+        end
       end
-    end
 
-    context "when explicit policy doesn't match" do
-      specify do
-        expect do
+      context "with fallback rule" do
+        specify do
           expect { subject.say("admin") }
-            .to be_authorized_to(:manage?, target).with(UserPolicy)
-        end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+            .to be_authorized_to(:manage?, target).with(TestService::CustomPolicy)
+        end
       end
     end
 
-    context "when rule doesn't match" do
-      specify do
-        expect do
-          expect { subject.say("admin") }
-            .to be_authorized_to(:say?, target).with(UserPolicy)
-        end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+    context "when authorization hasn't been performed" do
+      context "when target doesn't match" do
+        specify do
+          expect do
+            expect { subject.talk("adminos") }
+              .to be_authorized_to(:update?, target)
+          end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+        end
+      end
+
+      context "when implicit policy doesn't match" do
+        specify do
+          expect do
+            expect { subject.say("adminos") }
+              .to be_authorized_to(:manage?, target)
+          end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+        end
+      end
+
+      context "when explicit policy doesn't match" do
+        specify do
+          expect do
+            expect { subject.say("admin") }
+              .to be_authorized_to(:manage?, target).with(UserPolicy)
+          end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+        end
+      end
+
+      context "when rule doesn't match" do
+        specify do
+          expect do
+            expect { subject.say("admin") }
+              .to be_authorized_to(:say?, target).with(UserPolicy)
+          end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+        end
+      end
+
+      context "when no authorization performed" do
+        specify do
+          expect do
+            expect { subject.speak("admin") }
+              .to be_authorized_to(:manage?, target).with(UserPolicy)
+          end.to raise_error(
+            RSpec::Expectations::ExpectationNotMetError,
+            %r{expected.+to be authorized with UserPolicy#manage?}
+          )
+        end
+      end
+
+      context "when allowed_to? performed" do
+        specify do
+          expect do
+            expect { subject.talk?("admin") }
+              .to be_authorized_to(:manage?, target).with(UserPolicy)
+          end.to raise_error(
+            RSpec::Expectations::ExpectationNotMetError,
+            /but no authorization calls have been made/
+          )
+        end
       end
     end
 
-    context "when no authorization performed" do
-      specify do
+    context "matcher errors" do
+      specify "negation is not supported" do
         expect do
-          expect { subject.speak("admin") }
-            .to be_authorized_to(:manage?, target).with(UserPolicy)
-        end.to raise_error(
-          RSpec::Expectations::ExpectationNotMetError,
-          %r{expected.+to be authorized with UserPolicy#manage?}
-        )
+          expect { subject.talk("admin") }
+            .not_to be_authorized_to(:update?, target)
+        end.to raise_error(/doesn't support negation/)
       end
-    end
 
-    context "when allowed_to? performed" do
-      specify do
+      specify "block is required" do
         expect do
-          expect { subject.talk?("admin") }
-            .to be_authorized_to(:manage?, target).with(UserPolicy)
-        end.to raise_error(
-          RSpec::Expectations::ExpectationNotMetError,
-          /but no authorization calls have been made/
-        )
+          expect(subject).to be_authorized_to(:update?, target)
+        end.to raise_error(/only supports block expectations/)
       end
     end
   end
 
-  context "matcher errors" do
-    specify "negation is not supported" do
-      expect do
-        expect { subject.talk("admin") }
-          .not_to be_authorized_to(:update?, target)
-      end.to raise_error(/doesn't support negation/)
+  describe "#have_authorized_scope" do
+    let(:target) { [User.new("admin")] }
+
+    context "when scoping is performed" do
+      specify "with default scope" do
+        expect { subject.filter(target) }
+          .to have_authorized_scope(:data).with(TestService::CustomPolicy)
+      end
+
+      specify "with named scope" do
+        expect { subject.own(target) }
+          .to have_authorized_scope(:data).with(UserPolicy).as(:own)
+      end
     end
 
-    specify "block is required" do
-      expect do
-        expect(subject).to be_authorized_to(:update?, target)
-      end.to raise_error(/only supports block expectations/)
+    context "when no scoping performed" do
+      specify "type mismatch" do
+        expect do
+          expect { subject.filter(target) }
+            .to have_authorized_scope(:datum).with(TestService::CustomPolicy)
+        end.to raise_error(
+          RSpec::Expectations::ExpectationNotMetError,
+          %r{expected a scoping named :default for type :datum from TestService::CustomPolicy to have been applied}
+        )
+      end
+
+      specify "policy mismatch" do
+        expect do
+          expect { subject.filter(target) }
+            .to have_authorized_scope(:data).with(UserPolicy)
+        end.to raise_error(
+          RSpec::Expectations::ExpectationNotMetError,
+          %r{expected a scoping named :default for type :data from UserPolicy to have been applied}
+        )
+      end
+
+      specify "name mismatch" do
+        expect do
+          expect { subject.own(target) }
+            .to have_authorized_scope(:data).with(UserPolicy)
+        end.to raise_error(
+          RSpec::Expectations::ExpectationNotMetError,
+          %r{expected a scoping named :default for type :data from UserPolicy to have been applied}
+        )
+      end
     end
   end
 end

--- a/test/action_policy/policy/scoping_test.rb
+++ b/test/action_policy/policy/scoping_test.rb
@@ -145,42 +145,18 @@ class TestPolicyScopeMatchers < Minitest::Test
 
     policy = UserPolicy.new(user: User.new("guest"))
 
-    scoped_users = policy.apply_scope(users)
+    scope_type = policy.resolve_scope_type(users)
 
-    assert_equal 1, scoped_users.size
-    assert_equal "jack", scoped_users.first.name
-
-    policy = UserPolicy.new(user: User.new("admin"))
-
-    scoped_users = policy.apply_scope(users)
-    assert_equal 2, scoped_users.size
-
-    users_hash = { a: User.new("jack"), b: User.new("admin") }
-
-    policy = UserPolicy.new(user: User.new("guest"))
-
-    scoped_users = policy.apply_scope(users_hash)
-
-    assert_equal({ a: User.new("jack") }, scoped_users)
+    assert_equal :hash_or_array, scope_type
   end
 
   def test_class_matcher
     payload = Payload.new("a", 2)
-    payload2 = Payload.new("a", 0)
-
     policy = GuestPolicy.new(user: User.new("guest"))
-    scoped_payload = policy.apply_scope(payload)
 
-    assert_nil scoped_payload
+    scope_type = policy.resolve_scope_type(payload)
 
-    scoped_payload = policy.apply_scope(payload2)
-
-    assert_equal payload2, scoped_payload
-
-    policy = GuestPolicy.new(user: User.new("admin"))
-    scoped_payload = policy.apply_scope(payload)
-
-    assert_equal payload, scoped_payload
+    assert_equal :payload, scope_type
   end
 
   def test_no_matching_type
@@ -188,7 +164,7 @@ class TestPolicyScopeMatchers < Minitest::Test
     policy = UserPolicy.new(user: User.new("guest"))
 
     e = assert_raises ActionPolicy::UnrecognizedScopeTarget do
-      policy.apply_scope(payload)
+      policy.resolve_scope_type(payload)
     end
 
     assert_includes e.message,


### PR DESCRIPTION
Follow-up for #33.

Added testing support to scopes.

Example:

```ruby
# users_controller.rb
class UsersController < ApplicationController
  def index
    @user = authorized(User.all)
  end
end

# users_controller_spec.rb
describe UsersController do
  subject { get :index }
   it "has authorized scope" do
    expect { subject }.to have_authorized_scope(:active_record_relation)
      .with(PostPolicy)
  end
end
```