### PR TITLE
Remove duplicated `config.` from CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@
 
   It could be disabled by setting `ActionPolicy::LookupChain.namespace_cache_enabled = false`. It's enabled by default unless `RACK_ENV` env var is specified and is not equal to `"production"` (e.g. when `RACK_ENV=test` the cache is disabled).
 
-  When using Rails it's enabled only in production mode but could be configured through setting the `config.config.action_policy.namespace_cache_enabled` parameter.
+  When using Rails it's enabled only in production mode but could be configured through setting the `config.action_policy.namespace_cache_enabled` parameter.
 
 - [Fix [#18](https://github.com/palkan/action_policy/issues/18)] Clarify documentation around, and fix the way `resolve_rule` resolves rules and rule aliases when subclasses are involved. ([@brendon][])
 


### PR DESCRIPTION
This was a typo made in 1d4a2e720c0da469d89240abdbd1c44a2daafb1b. There was a PR to correct this in `docs/namespaces.md` (https://github.com/palkan/action_policy/pull/38) but the typo remained in the `CHANGELOG`.