### PR TITLE
Ability to add options to scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,8 @@
   # user_policy.rb
   describe UserPolicy < Application do
     relation_scope do |relation, with_deleted: false|
-      some_logic(relation).yield_self do |rel|
-        with_deleted ? rel.with_deleted : rel
-      end
+      rel = some_logic(relation)
+      with_deleted ? rel.with_deleted : rel
     end
   end
   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,8 @@
   # user_policy.rb
   describe UserPolicy < Application do
     relation_scope do |relation, with_deleted: false|
-      if with_deleted
-        some_logic(relation)
-      else
-        another_logic(relation)
+      some_logic(relation).yield_self do |rel|
+        with_deleted ? rel.with_deleted : rel
       end
     end
   end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 ## master
 
+- Added scope options to scopes. ([@korolvs][])
+
+  See [#47](https://github.com/palkan/action_policy/pull/47).
+
+  Example:
+  ```ruby
+  # users_controller.rb
+  class UsersController < ApplicationController
+    def index
+      @user = authorized(User.all, scope_options: { with_deleted: true })
+    end
+  end
+
+  # user_policy.rb
+  describe UserPolicy < Application do
+    relation_scope do |relation, with_deleted: false|
+      if with_deleted
+        some_logic(relation)
+      else
+        another_logic(relation)
+      end
+    end
+  end
+  ```
+
 - Added testing for scopes. ([@palkan][])
 
   Example:
@@ -146,3 +171,4 @@
 [@palkan]: https://github.com/palkan
 [@ilyasgaraev]: https://github.com/ilyasgaraev
 [@brendon]: https://github.com/brendon
+[@korolvs]: https://github.com/korolvs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@
         another_logic(relation)
       end
     end
-    
+  end
+  ```
+
 - Added Symbol lookup to the lookup chain ([@DmitryTsepelev][])
 
   For instance, lookup will implicitly use `AdminPolicy` in a following case:

--- a/docs/scoping.md
+++ b/docs/scoping.md
@@ -79,9 +79,9 @@ For example, if you use soft-deletion and your logic inside a scope depends on i
 class PostPolicy < ApplicationPolicy
   scope_for :relation do |relation, with_deleted: false|
     if with_deleted
-      # Code that runs if deleted records are included
+      some_logic(relation) # Code that runs if deleted records are included
     else
-      # Code that runs if deleted records are not included
+      another_logic(relation) # Code that runs if deleted records are not included
     end
   end
 end

--- a/docs/scoping.md
+++ b/docs/scoping.md
@@ -71,6 +71,31 @@ end
 
 When the second argument is not speficied, the `:default` is implied as the scope name.
 
+Also, there are cases where it might be easier to add options to existing scope than create a new one.
+
+For example, if you use soft-deletion and your logic inside a scope depends on if deleted records are included, you can add `with_deleted` option:
+
+```ruby
+class PostPolicy < ApplicationPolicy
+  scope_for :relation do |relation, with_deleted: false|
+    if with_deleted
+      # Code that runs if deleted records are included
+    else
+      # Code that runs if deleted records are not included
+    end
+  end
+end
+```
+
+You can add as many options as you want:
+
+```ruby
+class PostPolicy < ApplicationPolicy
+  scope_for :relation do |relation, with_deleted: false, magic_number: 42, some_required_option:|
+    # Your code
+  end
+end
+```
 ## Apply scopes
 
 Action Policy behaviour (`ActionPolicy::Behaviour`) provides an `authorized` method which allows you to use scoping:
@@ -86,6 +111,9 @@ class PostsController < ApplicationController
     #
     # For named scopes provide `as` option
     @events = authorized(Event, type: :relation, as: :own)
+    #
+    # If you want to specify scope options provide `scope_options` option
+    @events = authorized(Event, type: :relation, scope_options: { with_deleted: true })
   end
 end
 ```

--- a/docs/scoping.md
+++ b/docs/scoping.md
@@ -78,10 +78,8 @@ For example, if you use soft-deletion and your logic inside a scope depends on i
 ```ruby
 class PostPolicy < ApplicationPolicy
   scope_for :relation do |relation, with_deleted: false|
-    if with_deleted
-      some_logic(relation) # Code that runs if deleted records are included
-    else
-      another_logic(relation) # Code that runs if deleted records are not included
+    some_logic(relation).yield_self do |rel|
+      with_deleted ? rel.with_deleted : rel
     end
   end
 end

--- a/docs/scoping.md
+++ b/docs/scoping.md
@@ -78,9 +78,8 @@ For example, if you use soft-deletion and your logic inside a scope depends on i
 ```ruby
 class PostPolicy < ApplicationPolicy
   scope_for :relation do |relation, with_deleted: false|
-    some_logic(relation).yield_self do |rel|
-      with_deleted ? rel.with_deleted : rel
-    end
+    rel = some_logic(relation)
+    with_deleted ? rel.with_deleted : rel
   end
 end
 ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -154,7 +154,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 end
 ```
 
-You can also specify `as` option.
+You can also specify `as` and `scope_options` options.
 
 **NOTE:** both `type` and `with` params are required.
 
@@ -179,4 +179,11 @@ describe UsersController do
 end
 ```
 
-You can also add `.as(:named_scope)` option.
+You can also add `.as(:named_scope)` and `with_scope_options(options_hash)` options.
+
+RSpec composed matchers are available as scope options:
+
+```ruby
+expect { subject }.to have_authorized_scope(:scope)
+  .with_scope_options(matching(with_deleted: a_falsey_value))
+```

--- a/lib/action_policy/behaviour.rb
+++ b/lib/action_policy/behaviour.rb
@@ -59,13 +59,13 @@ module ActionPolicy
     #   - first, check whether `with` option is present
     #   - secondly, try to infer policy class from `target` (non-raising lookup)
     #   - use `implicit_authorization_target` if none of the above works.
-    def authorized(target, type: nil, as: :default, **options)
+    def authorized(target, type: nil, as: :default, scope_options: nil, **options)
       policy = policy_for(record: target, allow_nil: true, **options)
       policy ||= policy_for(record: implicit_authorization_target, **options)
 
       type ||= authorization_scope_type_for(policy, target)
 
-      Authorizer.scopify(target, policy, type: type, name: as)
+      Authorizer.scopify(target, policy, type: type, name: as, scope_options: scope_options)
     end
 
     def authorization_context

--- a/lib/action_policy/policy/scoping.rb
+++ b/lib/action_policy/policy/scoping.rb
@@ -89,14 +89,15 @@ module ActionPolicy
       # If `name` is not specified then `:default` name is used.
       # If `type` is not specified then we try to infer the type from the
       # target class.
-      def apply_scope(target, type:, name: :default)
+      def apply_scope(target, type:, name: :default, scope_options: nil)
         raise ActionPolicy::UnknownScopeType.new(self.class, type) unless
           self.class.scoping_handlers.key?(type)
 
         raise ActionPolicy::UnknownNamedScope.new(self.class, type, name) unless
           self.class.scoping_handlers[type].key?(name)
 
-        send(:"__scoping__#{type}__#{name}", target)
+        mid = :"__scoping__#{type}__#{name}"
+        scope_options ? send(mid, target, **scope_options) : send(mid, target)
       end
 
       def resolve_scope_type(target)

--- a/lib/action_policy/rspec/have_authorized_scope.rb
+++ b/lib/action_policy/rspec/have_authorized_scope.rb
@@ -70,7 +70,12 @@ module ActionPolicy
 
       def scope_options_message
         if scope_options
-          "with scope options #{scope_options}"
+          if defined?(::RSpec::Matchers::Composable) &&
+             scope_options.is_a?(::RSpec::Matchers::Composable)
+            "with scope options #{scope_options.description}"
+          else
+            "with scope options #{scope_options}"
+          end
         else
           "without scope options"
         end

--- a/lib/action_policy/rspec/have_authorized_scope.rb
+++ b/lib/action_policy/rspec/have_authorized_scope.rb
@@ -38,7 +38,7 @@ module ActionPolicy
         self
       end
 
-      def with_options(scope_options)
+      def with_scope_options(scope_options)
         @scope_options = scope_options
         self
       end
@@ -63,8 +63,17 @@ module ActionPolicy
 
       def failure_message
         "expected a scoping named :#{name} for type :#{type} " \
+        "#{scope_options_message} " \
         "from #{policy} to have been applied, " \
         "but #{actual_scopes_message}"
+      end
+
+      def scope_options_message
+        if scope_options
+          "with scope options #{scope_options}"
+        else
+          "without scope options"
+        end
       end
 
       def actual_scopes_message

--- a/lib/action_policy/rspec/have_authorized_scope.rb
+++ b/lib/action_policy/rspec/have_authorized_scope.rb
@@ -20,11 +20,12 @@ module ActionPolicy
     #   end
     #
     class HaveAuthorizedScope < ::RSpec::Matchers::BuiltIn::BaseMatcher
-      attr_reader :type, :name, :policy, :actual_scopes
+      attr_reader :type, :name, :policy, :scope_options, :actual_scopes
 
       def initialize(type)
         @type = type
         @name = :default
+        @scope_options = nil
       end
 
       def with(policy)
@@ -37,6 +38,11 @@ module ActionPolicy
         self
       end
 
+      def with_options(scope_options)
+        @scope_options = scope_options
+        self
+      end
+
       def match(_expected, actual)
         raise "This matcher only supports block expectations" unless actual.is_a?(Proc)
 
@@ -44,7 +50,7 @@ module ActionPolicy
 
         @actual_scopes = ActionPolicy::Testing::AuthorizeTracker.scopings
 
-        actual_scopes.any? { |scope| scope.matches?(policy, type, name) }
+        actual_scopes.any? { |scope| scope.matches?(policy, type, name, scope_options) }
       end
 
       def does_not_match?(*)

--- a/lib/action_policy/test_helper.rb
+++ b/lib/action_policy/test_helper.rb
@@ -56,7 +56,7 @@ module ActionPolicy
     # NOTE: `type` and `with` must be specified.
     #
     # rubocop: disable Metrics/MethodLength
-    def assert_have_authorized_scope(type:, with:, as: :default)
+    def assert_have_authorized_scope(type:, with:, as: :default, scope_options: nil)
       raise ArgumentError, "Block is required" unless block_given?
 
       policy = with
@@ -66,7 +66,7 @@ module ActionPolicy
       actual_scopes = ActionPolicy::Testing::AuthorizeTracker.scopings
 
       assert(
-        actual_scopes.any? { |scope| scope.matches?(policy, type, as) },
+        actual_scopes.any? { |scope| scope.matches?(policy, type, as, scope_options) },
         "Expected a scoping named :#{as} for :#{type} type from #{policy} to have been applied, " \
         "but no such scoping has been made.\n" \
         "Registered scopings: " \

--- a/lib/action_policy/test_helper.rb
+++ b/lib/action_policy/test_helper.rb
@@ -65,9 +65,17 @@ module ActionPolicy
 
       actual_scopes = ActionPolicy::Testing::AuthorizeTracker.scopings
 
+      scope_options_message = if scope_options
+                                "with scope options #{scope_options}"
+                              else
+                                "without scope options"
+                              end
+
       assert(
         actual_scopes.any? { |scope| scope.matches?(policy, type, as, scope_options) },
-        "Expected a scoping named :#{as} for :#{type} type from #{policy} to have been applied, " \
+        "Expected a scoping named :#{as} for :#{type} type " \
+        "#{scope_options_message} " \
+        "from #{policy} to have been applied, " \
         "but no such scoping has been made.\n" \
         "Registered scopings: " \
         "#{actual_scopes.empty? ? 'none' : actual_scopes.map(&:inspect).join(',')}"

--- a/lib/action_policy/testing.rb
+++ b/lib/action_policy/testing.rb
@@ -34,11 +34,11 @@ module ActionPolicy
           @scope_options = scope_options
         end
 
-        def matches?(policy_class, actual_type, actual_name, actual_scoping)
+        def matches?(policy_class, actual_type, actual_name, actual_scope_options)
           policy_class == policy.class &&
             type == actual_type &&
             name == actual_name &&
-            scope_options == actual_scoping
+            scope_options == actual_scope_options
         end
 
         def inspect

--- a/lib/action_policy/testing.rb
+++ b/lib/action_policy/testing.rb
@@ -38,7 +38,7 @@ module ActionPolicy
           policy_class == policy.class &&
             type == actual_type &&
             name == actual_name &&
-            scope_options == actual_scope_options
+            actual_scope_options === scope_options # rubocop:disable Style/CaseEquality
         end
 
         def inspect
@@ -49,7 +49,12 @@ module ActionPolicy
 
         def scope_options_message
           if scope_options
-            "with scope options #{scope_options}"
+            if defined?(::RSpec::Matchers::Composable) &&
+               scope_options.is_a?(::RSpec::Matchers::Composable)
+              "with scope options #{scope_options.description}"
+            else
+              "with scope options #{scope_options}"
+            end
           else
             "without scope options"
           end

--- a/lib/action_policy/testing.rb
+++ b/lib/action_policy/testing.rb
@@ -25,18 +25,20 @@ module ActionPolicy
       end
 
       class Scoping # :nodoc:
-        attr_reader :policy, :type, :name
+        attr_reader :policy, :type, :name, :scope_options
 
-        def initialize(policy, type, name)
+        def initialize(policy, type, name, scope_options)
           @policy = policy
           @type = type
           @name = name
+          @scope_options = scope_options
         end
 
-        def matches?(policy_class, actual_type, actual_name)
+        def matches?(policy_class, actual_type, actual_name, actual_scoping)
           policy_class == policy.class &&
             type == actual_type &&
-            name == actual_name
+            name == actual_name &&
+            scope_options == actual_scoping
         end
 
         def inspect
@@ -63,9 +65,9 @@ module ActionPolicy
         end
 
         # Called from Authorizer
-        def track_scope(_target, policy, type:, name:)
+        def track_scope(_target, policy, type:, name:, scope_options:)
           return unless tracking?
-          scopings << Scoping.new(policy, type, name)
+          scopings << Scoping.new(policy, type, name, scope_options)
         end
 
         def calls

--- a/lib/action_policy/testing.rb
+++ b/lib/action_policy/testing.rb
@@ -42,7 +42,17 @@ module ActionPolicy
         end
 
         def inspect
-          "#{policy.class} :#{name} for :#{type}"
+          "#{policy.class} :#{name} for :#{type} #{scope_options_message}"
+        end
+
+        private
+
+        def scope_options_message
+          if scope_options
+            "with scope options #{scope_options}"
+          else
+            "without scope options"
+          end
         end
       end
 

--- a/spec/action_policy/rspec_spec.rb
+++ b/spec/action_policy/rspec_spec.rb
@@ -176,7 +176,14 @@ describe "ActionPolicy RSpec matchers" do
 
       specify "with scope options" do
         expect { subject.filter_with_options(target, with_admins: true) }
-          .to have_authorized_scope(:data).with(TestService::CustomPolicy).with_scope_options(with_admins: true)
+          .to have_authorized_scope(:data).with(TestService::CustomPolicy)
+          .with_scope_options(with_admins: true)
+      end
+
+      specify "with composed scope options" do
+        expect { subject.filter_with_options(target, with_admins: true) }
+          .to have_authorized_scope(:data).with(TestService::CustomPolicy)
+          .with_scope_options(matching(with_admins: a_truthy_value))
       end
     end
 
@@ -217,12 +224,26 @@ describe "ActionPolicy RSpec matchers" do
       specify "scope options mismatch" do
         expect do
           expect { subject.filter_with_options(target, with_admins: true) }
-            .to have_authorized_scope(:data).with(UserPolicy).with_scope_options(with_admins: false)
+            .to have_authorized_scope(:data).with(TestService::CustomPolicy)
+            .with_scope_options(with_admins: false)
         end.to raise_error(
           RSpec::Expectations::ExpectationNotMetError,
           Regexp.new("expected a scoping named :default for type :data " \
                      "with scope options {:with_admins=>false} " \
-                     "from UserPolicy to have been applied")
+                     "from TestService::CustomPolicy to have been applied")
+        )
+      end
+
+      specify "composed scope options mismatch" do
+        expect do
+        expect { subject.filter_with_options(target, with_admins: true) }
+          .to have_authorized_scope(:data).with(TestService::CustomPolicy)
+          .with_scope_options(matching(with_admins: a_falsey_value))
+        end.to raise_error(
+          RSpec::Expectations::ExpectationNotMetError,
+          Regexp.new("expected a scoping named :default for type :data " \
+                     'with scope options matching {:with_admins=>\(a falsey value\)} ' \
+                     "from TestService::CustomPolicy to have been applied")
         )
       end
     end

--- a/test/action_policy/behaviour_test.rb
+++ b/test/action_policy/behaviour_test.rb
@@ -96,6 +96,19 @@ class TestAuthorizedBehaviour < Minitest::Test
     assert_equal 2, scoped_users.size
   end
 
+  def test_default_authorized_with_scope_options
+    chat = ChatChannel.new("guest")
+
+    scoped_users = chat.authorized(users, type: :data)
+
+    assert_equal 1, scoped_users.size
+    assert_equal "jack", scoped_users.first.name
+
+    scoped_users = chat.authorized(users, type: :data, scope_options: { with_admins: true })
+
+    assert_equal 2, scoped_users.size
+  end
+
   def test_named_authorized
     chat = ChatChannel.new("guest")
 

--- a/test/stubs/user.rb
+++ b/test/stubs/user.rb
@@ -20,8 +20,8 @@ class User
 end
 
 class UserPolicy < ActionPolicy::Base
-  scope_for :data do |users|
-    next users if user.admin?
+  scope_for :data do |users, with_admins: false|
+    next users if user.admin? || with_admins
     users.reject(&:admin?)
   end
 


### PR DESCRIPTION
Hi! Thank you for a great gem!

### What is the purpose of this pull request?

Add the ability to add options to Scopes so it can be declared like this: 

```
scope_for :relation do |relation, with_deleted: false, whatever: 42|
  ...
end
```

And instead of several scopes can be created only one

It can be used this way:

```
authorized blabla, type: :relation, scope_options: { with_deleted: true }

```

`authorized(blabla, type: :relation, with_deleted: true)` would look better, but I don't think we need to mix policy lookup options with scope options

### What changes did you make? (overview)

- Added scope_options to `Behaviour#authorized`
- Added scope_options to `Scoping#apply_scope` and made it pass to the policy only when options are present to not break existing scopes which don't expect options
- Updated existing tests to be green

### Is there anything you'd like reviewers to focus on?

If you like the idea and the syntax, I'll add specs, documentation, and changelog for it

PR checklist:

- [x] Tests included
- [x] Documentation updated
- [x] Changelog entry added
