### PR TITLE
I18n integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## master
 
+- Added I18n support ([@DmitryTsepelev][])
+
+  Example:
+
+  ```ruby
+  class ApplicationController < ActionController::Base
+    rescue_from ActionPolicy::Unauthorized do |ex|
+      p ex.result.message #=> "You do not have access to the stage"
+      p ex.result.reasons.full_messages #=> ["You do not have access to the stage"]
+    end
+  end
+  ```
+
 - Added scope options to scopes. ([@korolvs][])
 
   See [#47](https://github.com/palkan/action_policy/pull/47).

--- a/action_policy.gemspec
+++ b/action_policy.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop", "~> 0.56.0"
   spec.add_development_dependency "rubocop-md", "~> 0.2"
   spec.add_development_dependency "benchmark-ips", "~> 2.7.0"
+  spec.add_development_dependency "i18n"
 end

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,5 +1,34 @@
 # I18n Support
 
-🛠 **WORK IN PROGRESS**
+`ActionPolicy` fully supports localizable `full_messages` and result's `message`, which could be used in the following way:
 
-Follow [the issue](https://github.com/palkan/action_policy/issues/15).
+```ruby
+class ApplicationController < ActionController::Base
+  rescue_from ActionPolicy::Unauthorized do |ex|
+    p ex.result.message #=> "You do not have access to the stage"
+    p ex.result.reasons.full_messages #=> ["You do not have access to the stage"]
+  end
+end
+```
+
+The message contains a string for the _rule_ that was called, while `full_messages` contains the list of reasons, why `ActionPolicy::Unauthorized` has been raised. You can find more information about tracking failure reasons [here](reasons.md).
+
+## Configuration
+
+`ActionPolicy` is shipped with the default , which is used as the default fallback message "You are not authorized to perform this action". You can add your app-level default fallback by providing a value to the key `en.action_policy.unauthorized`. If you're using **Rails** - you can add translations to any file inside your `config/locales` folder (or create a new file, e.g. `config/locales/policies.yml`). Non-Rails users should install `i18n` gem and let it know where to find locales:
+
+```ruby
+I18n.load_path << Dir[File.expand_path("config/locales") + "/*.yml"]
+```
+
+## Translations lookup
+
+To find the message for result or reason, `ActionPolicy` looks at the `action_policy` scope. All the translations for the concrete policies are inside the `policy` sub-scope. The following algorithm is used to find out the translation for a policy with a class `klass` and rule `rule`:
+
+1. Translation for `"#{klass.identifier}.#{rule}"` key, when `self.identifier =` is not specified then underscored class name without the _Policy_ suffix would be used (e.g. `GuestUserPolicy` turns into `guest_user:` scope)
+2. Repeat step 1 for each ancestor which looks like a policy (`.respond_to?(:identifier)?`) up to `ActionPolicy::Base`
+3. Use `#{rule}` key
+4. Use `en.action_policy.unauthorized` key
+5. Use a default message provided by gem
+
+For example, given a `GuestUserPolicy` class which is inherited from `DefaultUserPolicy` and a rule `feed?`, the following list of possible translation keys would be used: `[:"action_policy.policy.guest_user.feed?", :"action_policy.policy.default_user.feed?", :"action_policy.policy.feed?", :"action_policy.unauthorized"]`

--- a/docs/reasons.md
+++ b/docs/reasons.md
@@ -32,8 +32,6 @@ end
 
 The reason key is the corresponding policy [identifier](writing_policies.md#identifiers).
 
-**NOTE:** `full_messages` support hasn't been released yet. See [the issue](https://github.com/palkan/action_policy/issues/15).
-
 You can also wrap _local_ rules into `allowed_to?` to populate reasons:
 
 ```ruby

--- a/lib/action_policy.rb
+++ b/lib/action_policy.rb
@@ -21,6 +21,7 @@ module ActionPolicy
   require "action_policy/base"
   require "action_policy/lookup_chain"
   require "action_policy/behaviour"
+  require "action_policy/i18n" if defined?(::I18n)
 
   class << self
     attr_accessor :cache_store

--- a/lib/action_policy/i18n.rb
+++ b/lib/action_policy/i18n.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module ActionPolicy
+  module I18n # :nodoc:
+    DEFAULT_UNAUTHORIZED_MESSAGE = "You are not authorized to perform this action"
+
+    class << self
+      def full_message(policy_class, rule)
+        candidates = candidates_for(policy_class, rule)
+
+        ::I18n.t(
+          candidates.shift,
+          default: candidates,
+          scope: :action_policy
+        )
+      end
+
+      private
+
+      def candidates_for(policy_class, rule)
+        policy_hierarchy = policy_class.ancestors.select { |klass| klass.respond_to?(:identifier) }
+        [
+          *policy_hierarchy.map { |klass| :"policy.#{klass.identifier}.#{rule}" },
+          :"policy.#{rule}",
+          :unauthorized,
+          DEFAULT_UNAUTHORIZED_MESSAGE
+        ]
+      end
+    end
+
+    ActionPolicy::Policy::FailureReasons.prepend(Module.new do
+      def full_messages
+        reasons.flat_map do |policy_klass, rules|
+          rules.map { |rule| ActionPolicy::I18n.full_message(policy_klass, rule) }
+        end
+      end
+    end)
+
+    ActionPolicy::Policy::ExecutionResult.prepend(Module.new do
+      def message
+        ActionPolicy::I18n.full_message(policy, rule)
+      end
+    end)
+  end
+end

--- a/test/action_policy/i18n_test.rb
+++ b/test/action_policy/i18n_test.rb
@@ -1,0 +1,199 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class I18nDefaultPolicy < ActionPolicy::Base
+  def feed?
+    allowed_to?(:access_feed?)
+  end
+
+  def edit?
+    allowed_to?(:admin?)
+  end
+
+  def admin?
+    user.admin?
+  end
+
+  def access_feed?
+    false
+  end
+end
+
+class I18nLocalizedIdentifiedPolicy < I18nDefaultPolicy
+  self.identifier = :identified_policy
+end
+
+class I18nLocalizedPolicy < I18nDefaultPolicy; end
+
+class I18nInheritedFromLocalizedPolicy < I18nLocalizedPolicy; end
+
+class I18nIncludingCoreLocalizedPolicy
+  include ActionPolicy::Policy::Core
+  include ActionPolicy::Policy::Reasons
+
+  def edit?
+    allowed_to?(:admin?)
+  end
+
+  def admin?
+    false
+  end
+end
+
+class TestI18nGlobalDefaults < Minitest::Test
+  def setup
+    I18n.backend.store_translations(:en, action_policy: { policy: {} })
+    @user = User.new("guest")
+  end
+
+  def test_result_message_fallbacks_to_global_default
+    policy = I18nDefaultPolicy.new(user: @user)
+    refute policy.apply(:edit?)
+    assert_equal policy.result.message,
+                 ActionPolicy::I18n::DEFAULT_UNAUTHORIZED_MESSAGE
+  end
+
+  def test_full_messages_fallback_to_global_default
+    policy = I18nDefaultPolicy.new(user: @user)
+    refute policy.apply(:feed?)
+    assert_includes policy.result.reasons.full_messages,
+                    ActionPolicy::I18n::DEFAULT_UNAUTHORIZED_MESSAGE
+  end
+end
+
+class TestI18nAppDefaults < Minitest::Test
+  def setup
+    I18n.backend.store_translations(
+      :en,
+      action_policy: {
+        unauthorized: "This action is not allowed",
+        policy: {
+          feed?: "You're not authorized to access the feed",
+          admin?: "Only admins are authorized to view this data"
+        }
+      }
+    )
+
+    @user = User.new("guest")
+  end
+
+  def teardown
+    I18n.backend.reload!
+  end
+
+  def test_result_message_fallbacks_to_app_default
+    policy = I18nDefaultPolicy.new(user: @user)
+    refute policy.apply(:edit?)
+    assert_equal policy.result.message, "This action is not allowed"
+  end
+
+  def test_full_messages_fallback_to_app_default
+    policy = I18nDefaultPolicy.new(user: @user)
+    refute policy.apply(:feed?)
+    assert_includes policy.result.reasons.full_messages, "This action is not allowed"
+  end
+
+  def test_result_message_fallbacks_to_action_default
+    policy = I18nDefaultPolicy.new(user: @user)
+    refute policy.apply(:feed?)
+    assert_equal policy.result.message, "You're not authorized to access the feed"
+  end
+
+  def test_full_messages_fallback_to_action_default
+    policy = I18nDefaultPolicy.new(user: @user)
+    refute policy.apply(:edit?)
+    assert_includes policy.result.reasons.full_messages,
+                    "Only admins are authorized to view this data"
+  end
+end
+
+class TestI18nPolicies < Minitest::Test
+  def setup
+    I18n.backend.store_translations(
+      :en,
+      action_policy: {
+        policy: {
+          i18n_localized: {
+            edit?: "You are not authorized to read this data according to custom policy",
+            admin?: "You are not authorized to access feed according to custom policy"
+          },
+          i18n_inherited_from_localized: {
+            edit?: "You are not authorized to read this data according to custom inherited policy",
+            admin?: "You are not authorized to access feed according to inherited policy"
+          },
+          identified_policy: {
+            edit?: "You are not authorized to read this data according to identified policy",
+            admin?: "You are not authorized to access feed according to identified policy"
+          },
+          i18n_including_core_localized: {
+            edit?: "You are not authorized to read this data according to policy including core",
+            admin?: "You are not authorized to access feed according to policy including core"
+          }
+        }
+      }
+    )
+
+    @user = User.new("guest")
+  end
+
+  def teardown
+    I18n.backend.reload!
+  end
+
+  def test_result_message_for_localized_policy
+    policy = I18nLocalizedPolicy.new(user: @user)
+    refute policy.apply(:edit?)
+    assert_includes policy.result.message,
+                    "You are not authorized to read this data according to custom policy"
+  end
+
+  def test_full_messages_for_localized_policy
+    policy = I18nLocalizedPolicy.new(user: @user)
+    refute policy.apply(:edit?)
+    assert_includes policy.result.reasons.full_messages,
+                    "You are not authorized to access feed according to custom policy"
+  end
+
+  def test_result_message_for_inherited_localized_policy
+    policy = I18nInheritedFromLocalizedPolicy.new(user: @user)
+    refute policy.apply(:edit?)
+    assert_includes policy.result.message,
+                    "You are not authorized to read this data according to custom inherited policy"
+  end
+
+  def test_full_messages_for_inherited_localized_policy
+    policy = I18nInheritedFromLocalizedPolicy.new(user: @user)
+    refute policy.apply(:edit?)
+    assert_includes policy.result.reasons.full_messages,
+                    "You are not authorized to access feed according to inherited policy"
+  end
+
+  def test_result_message_for_identified_localized_policy
+    policy = I18nLocalizedIdentifiedPolicy.new(user: @user)
+    refute policy.apply(:edit?)
+    assert_includes policy.result.message,
+                    "You are not authorized to read this data according to identified policy"
+  end
+
+  def test_full_messages_message_for_identified_localized_policy
+    policy = I18nLocalizedIdentifiedPolicy.new(user: @user)
+    refute policy.apply(:edit?)
+    assert_includes policy.result.reasons.full_messages,
+                    "You are not authorized to access feed according to identified policy"
+  end
+
+  def test_result_message_for_localized_policy_including_core
+    policy = I18nIncludingCoreLocalizedPolicy.new
+    refute policy.apply(:edit?)
+    assert_includes policy.result.message,
+                    "You are not authorized to read this data according to policy including core"
+  end
+
+  def test_full_messages_message_for_localized_policy_including_core
+    policy = I18nIncludingCoreLocalizedPolicy.new
+    refute policy.apply(:edit?)
+    assert_includes policy.result.reasons.full_messages,
+                    "You are not authorized to access feed according to policy including core"
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "i18n"
+
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
 ENV["RAILS_ENV"] = "test"


### PR DESCRIPTION
I've tried to keep it as similar as much to the [gist](https://gist.github.com/palkan/eb6fab36c5f60e899cccacd3d5649a93) as possible. The major change is that I've added translations of the parent policies to the candidates' list.

I've also added two more Rake tasks for i18n specs, which cover the case when i18n gem is available and also when it's missing (i.e. user tries to use without requiring the gem)

Fixes #15.