### PR TITLE
Fix minor typos in documentation

### DIFF
--- a/docs/behaviour.md
+++ b/docs/behaviour.md
@@ -77,7 +77,7 @@ authorize! post, to: :destroy?, namespace: Admin
 
 ## Implicit authorization target
 
-You can ommit the authorization target for all the methods by defining an _implicit authorization target_:
+You can omit the authorization target for all the methods by defining an _implicit authorization target_:
 
 ```ruby
 class PostActions

--- a/docs/scoping.md
+++ b/docs/scoping.md
@@ -76,7 +76,7 @@ class EventPolicy < ApplictionPolicy
 end
 ```
 
-When the second argument is not speficied, the `:default` is implied as the scope name.
+When the second argument is not specified, the `:default` is implied as the scope name.
 
 Also, there are cases where it might be easier to add options to existing scope than create a new one.
 


### PR DESCRIPTION
Some minor typos I found while going trough the documentation.

Cheers!
