### PR TITLE
Add detailed reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 ## master
 
+- Added ability to provide additional failure reasons details. ([@palkan][])
+
+  Example:
+
+  ```ruby
+  class ApplicantPolicy < ApplicationPolicy
+    def show?
+      allowed_to?(:show?, object.stage)
+    end
+  end
+
+  class StagePolicy < ApplicationPolicy
+    def show?
+      # Add stage title to the failure reason (if any)
+      # (could be used by client to show more descriptive message)
+      details[:title] = record.title
+      # then perform the checks
+      user.stages.where(id: record.id).exists?
+    end
+  end
+
+  # when accessing the reasons
+  p ex.result.reasons.details #=> { stage: [{show?: {title: "Onboarding"}] }
+  ```
+
+  See https://github.com/palkan/action_policy/pull/58
+
 - Ruby 2.4+ is required. ([@palkan][])
 
 - Added RSpec DSL for writing policy specs. ([@palkan])

--- a/docs/reasons.md
+++ b/docs/reasons.md
@@ -53,9 +53,58 @@ p ex.result.reasons.details #=> { applicant: [:view_applicants?] }
 p ex.result.reasons.details #=> { stage: [:show?] }
 ```
 
+## Detailed Reasons
 
+**NOTE:** this feature hasn't been released yet and planned for 0.3.0 release.
+You can use it now by installing the gem from GitHub master:
 
-**What is the point of failure reasons?**
+```ruby
+gem "action_policy", github: "palkan/action_policy"
+```
+
+You can provide additional details to your failure reasons by using a `details: { ... }` option:
+
+```ruby
+class ApplicantPolicy < ApplicationPolicy
+  def show?
+    allowed_to?(:show?, object.stage)
+  end
+end
+
+class StagePolicy < ApplicationPolicy
+  def show?
+    # Add stage title to the failure reason (if any)
+    # (could be used by client to show more descriptive message)
+    details[:title] = record.title
+
+    # then perform the checks
+    user.stages.where(id: record.id).exists?
+  end
+end
+
+# when accessing the reasons
+p ex.result.reasons.details #=> { stage: [{show?: {title: "Onboarding"}] }
+```
+
+**NOTE**: when using detailed reasons, the `details` array contains as the last element
+a hash with ALL details reasons for the policy (in a form of `<rule> => <details>`).
+
+The additional details are especially helpful when combined with localization, 'cause you can you them as interpolation data source for your translations. For example, for the above policy:
+
+```yml
+en:
+  policy:
+    stage:
+      show?: "The %{title} stage is not accessible"
+```
+
+And then when you call `full_messages`:
+
+```ruby
+p ex.result.reasons.full_messages #=> The Onboarding stage is not accessible
+```
+
+**P.S. What is the point of failure reasons?**
 
 Failure reasons helps you to write _actionable_ error messages, i.e. to provide a user with helpful feedback.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -82,6 +82,8 @@ describe PostPolicy do
 end
 ```
 
+**NOTE:** DSL for focusing or skipping examples and groups is also available (e.g. `xdescribe_rule`, `fsucceed`, etc.).
+
 **NOTE:** the DSL is included only to example with the tag `type: :policy` or in the `spec/policies` folder. If you want to add this DSL to other examples, add `include ActionPolicy::RSpec::PolicyExampleGroup`.
 
 ### Testing scopes

--- a/lib/action_policy/policy/core.rb
+++ b/lib/action_policy/policy/core.rb
@@ -85,10 +85,10 @@ module ActionPolicy
 
       # Wrap code that could modify result
       # to prevent the current result modification
-      def with_clean_result
+      def with_clean_result # :nodoc:
         was_result = @result
-        res = yield
-        @result = was_result
+        yield
+        res, @result = @result, was_result
         res
       end
 

--- a/lib/action_policy/policy/execution_result.rb
+++ b/lib/action_policy/policy/execution_result.rb
@@ -26,6 +26,10 @@ module ActionPolicy
       def fail?
         @value == false
       end
+
+      def inspect
+        "<#{policy}##{rule}: #{@value}>"
+      end
     end
   end
 end

--- a/lib/action_policy/policy/reasons.rb
+++ b/lib/action_policy/policy/reasons.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "action_policy/ext/yield_self_then"
+using ActionPolicy::Ext::YieldSelfThen
+
 module ActionPolicy
   module Policy
     # Failures reasons store
@@ -70,6 +73,14 @@ module ActionPolicy
 
       def clear_details
         @details = nil
+      end
+
+      # Add reasons to inspect
+      def inspect
+        super.then do |str|
+          next str if reasons.empty?
+          str.sub(/>$/, " (reasons: #{reasons.details})")
+        end
       end
     end
 
@@ -150,7 +161,7 @@ module ActionPolicy
     module Reasons
       class << self
         def included(base)
-          base.result_class.include(ResultFailureReasons)
+          base.result_class.prepend(ResultFailureReasons)
         end
       end
 

--- a/spec/action_policy/dsl_spec.rb
+++ b/spec/action_policy/dsl_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "action_policy/rspec/dsl"
+
+class UserPolicy < ActionPolicy::Base
+  scope_for :data do |users, with_admins: false|
+    next users if user.admin? || with_admins
+    users.reject(&:admin?)
+  end
+
+  scope_for :data, :own do |users|
+    users.select { |u| u.name == user.name }
+  end
+
+  def index?
+    true
+  end
+
+  def create?
+    user.admin?
+  end
+
+  def show?
+    true
+  end
+
+  def manage?
+    user.admin? && !record.admin?
+  end
+end
+
+describe UserPolicy, type: :policy do
+  let(:user) { User.new("guest") }
+  let(:admin) { User.new("admin") }
+  let(:context) { {user: user} }
+
+  describe_rule :manage? do
+    let(:record) { User.new("guest") }
+
+    failed
+
+    succeed "when user is admin" do
+      let(:user) { admin }
+
+      failed "when target user is also admin", some: :tag do
+        let(:record) { User.new("admin") }
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What is the purpose of this pull request?

Add ability to provide additional information to failure reasons.

### What changes did you make? (overview)

Add `details` Hash to specify per-rule meta information:

```ruby
class ApplicantPolicy < ApplicationPolicy
  def show?
    allowed_to?(:show?, object.stage)
  end
end

class StagePolicy < ApplicationPolicy
  def show?
    # Add stage title to the failure reason (if any)
    # (could be used by client to show more descriptive message)
    details[:title] = record.title
     # then perform the checks
    user.stages.where(id: record.id).exists?
  end
end

# when accessing the reasons
p ex.result.reasons.details #=> { stage: [{show?: {title: "Onboarding"}] }
```

The main purpose of this feature is to generate more descriptive failure messages with i18n.

**No breaking public API changes**.

PR checklist:

- [x] Tests included
- [x] Documentation updated
- [x] Changelog entry added