### PR TITLE
Improve scoping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## master
 
+- Renamed `#authorized` to `#authorized_scope`. ([@palkan][])
+
+  **NOTE:** `#authorized` alias is also available.
+
 - Added `Policy#pp(rule)` method to print annotated rule source code. ([@palkan][])
 
   Example (debugging):

--- a/docs/scoping.md
+++ b/docs/scoping.md
@@ -128,6 +128,20 @@ You can also specify additional options for policy class inference (see [behavio
 @posts = authorized_scope(Post, with: CustomPostPolicy)
 ```
 
+## Using scopes within policy
+
+You can also use scopes within policy classes using the same `authorized_scope` method.
+For example:
+
+```ruby
+relation_scope(:edit) do |scope|
+  teachers = authorized_scope(Teacher.all, as: :edit)
+  scope
+    .joins(:teachers)
+    .where(teacher_id: teachers)
+end
+```
+
 ## Using scopes explicitly
 
 To use scopes without including Action Policy [behaviour](behaviour)

--- a/lib/action_policy/behaviour.rb
+++ b/lib/action_policy/behaviour.rb
@@ -59,7 +59,7 @@ module ActionPolicy
     #   - first, check whether `with` option is present
     #   - secondly, try to infer policy class from `target` (non-raising lookup)
     #   - use `implicit_authorization_target` if none of the above works.
-    def authorized(target, type: nil, as: :default, scope_options: nil, **options)
+    def authorized_scope(target, type: nil, as: :default, scope_options: nil, **options)
       policy = policy_for(record: target, allow_nil: true, **options)
       policy ||= policy_for(record: implicit_authorization_target, **options)
 
@@ -67,6 +67,9 @@ module ActionPolicy
 
       Authorizer.scopify(target, policy, type: type, name: as, scope_options: scope_options)
     end
+
+    # For backward compatibility
+    alias authorized authorized_scope
 
     def authorization_context
       return @__authorization_context if
@@ -94,7 +97,7 @@ module ActionPolicy
     # that would be used in case `record` is not specified in
     # `authorize!` and `allowed_to?` call.
     #
-    # It is also used to infer a policy for scoping (in `authorized` method).
+    # It is also used to infer a policy for scoping (in `authorized_scope` method).
     def implicit_authorization_target
       # no-op
     end

--- a/lib/action_policy/behaviours/policy_for.rb
+++ b/lib/action_policy/behaviours/policy_for.rb
@@ -18,6 +18,15 @@ module ActionPolicy
       def authorization_namespace
         # override to provide specific authorization namespace
       end
+
+      # Override this method to provide implicit authorization target
+      # that would be used in case `record` is not specified in
+      # `authorize!` and `allowed_to?` call.
+      #
+      # It is also used to infer a policy for scoping (in `authorized_scope` method).
+      def implicit_authorization_target
+        # no-op
+      end
     end
   end
 end

--- a/lib/action_policy/behaviours/scoping.rb
+++ b/lib/action_policy/behaviours/scoping.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module ActionPolicy
+  module Behaviours
+    # Adds `authorized_scop` method to behaviour
+    module Scoping
+      # Apply scope to the target of the specified type.
+      #
+      # NOTE: policy lookup consists of the following steps:
+      #   - first, check whether `with` option is present
+      #   - secondly, try to infer policy class from `target` (non-raising lookup)
+      #   - use `implicit_authorization_target` if none of the above works.
+      def authorized_scope(target, type: nil, as: :default, scope_options: nil, **options)
+        policy = policy_for(record: target, allow_nil: true, **options)
+        policy ||= policy_for(record: implicit_authorization_target, **options)
+
+        type ||= authorization_scope_type_for(policy, target)
+
+        Authorizer.scopify(target, policy, type: type, name: as, scope_options: scope_options)
+      end
+
+      # For backward compatibility
+      alias authorized authorized_scope
+
+      # Infer scope type for target if none provided.
+      # Raises an exception if type couldn't be inferred.
+      def authorization_scope_type_for(policy, target)
+        policy.resolve_scope_type(target)
+      end
+    end
+  end
+end

--- a/lib/action_policy/policy/scoping.rb
+++ b/lib/action_policy/policy/scoping.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "action_policy/behaviours/scoping"
+
 require "action_policy/utils/suggest_message"
 
 require "action_policy/ext/proc_case_eq"
@@ -84,6 +86,8 @@ module ActionPolicy
           base.extend ClassMethods
         end
       end
+
+      include ActionPolicy::Behaviours::Scoping
 
       # Pass target to the scope handler of the specified type and name.
       # If `name` is not specified then `:default` name is used.

--- a/lib/action_policy/test_helper.rb
+++ b/lib/action_policy/test_helper.rb
@@ -70,7 +70,7 @@ module ActionPolicy
     # NOTE: `type` and `with` must be specified.
     #
     # You can run additional assertions for the matching target (the object passed
-    # to the `authorized` method) by calling `with_target`:
+    # to the `authorized_scope` method) by calling `with_target`:
     #
     #   def test_authorize
     #     assert_have_authorized_scope(type: :active_record_relation, with: UserPolicy) do

--- a/spec/action_policy/rspec_spec.rb
+++ b/spec/action_policy/rspec_spec.rb
@@ -41,15 +41,15 @@ class TestService # :nodoc:
   end
 
   def filter(users)
-    authorized users, type: :data, with: CustomPolicy
+    authorized_scope users, type: :data, with: CustomPolicy
   end
 
   def filter_with_options(users, with_admins: false)
-    authorized users, type: :data, with: CustomPolicy, scope_options: {with_admins: with_admins}
+    authorized_scope users, type: :data, with: CustomPolicy, scope_options: {with_admins: with_admins}
   end
 
   def own(users)
-    authorized users, type: :data, as: :own, with: UserPolicy
+    authorized_scope users, type: :data, as: :own, with: UserPolicy
   end
 end
 

--- a/test/action_policy/behaviour_test.rb
+++ b/test/action_policy/behaviour_test.rb
@@ -84,14 +84,14 @@ class TestAuthorizedBehaviour < Minitest::Test
   def test_default_authorized
     chat = ChatChannel.new("guest")
 
-    scoped_users = chat.authorized(users, type: :data)
+    scoped_users = chat.authorized_scope(users, type: :data)
 
     assert_equal 1, scoped_users.size
     assert_equal "jack", scoped_users.first.name
 
     chat = ChatChannel.new("admin")
 
-    scoped_users = chat.authorized(users, type: :data)
+    scoped_users = chat.authorized_scope(users, type: :data)
 
     assert_equal 2, scoped_users.size
   end
@@ -99,12 +99,12 @@ class TestAuthorizedBehaviour < Minitest::Test
   def test_default_authorized_with_scope_options
     chat = ChatChannel.new("guest")
 
-    scoped_users = chat.authorized(users, type: :data)
+    scoped_users = chat.authorized_scope(users, type: :data)
 
     assert_equal 1, scoped_users.size
     assert_equal "jack", scoped_users.first.name
 
-    scoped_users = chat.authorized(users, type: :data, scope_options: {with_admins: true})
+    scoped_users = chat.authorized_scope(users, type: :data, scope_options: {with_admins: true})
 
     assert_equal 2, scoped_users.size
   end
@@ -112,13 +112,13 @@ class TestAuthorizedBehaviour < Minitest::Test
   def test_named_authorized
     chat = ChatChannel.new("guest")
 
-    scoped_users = chat.authorized(users, type: :data, as: :own)
+    scoped_users = chat.authorized_scope(users, type: :data, as: :own)
 
     assert_equal 0, scoped_users.size
 
     chat = ChatChannel.new("admin")
 
-    scoped_users = chat.authorized(users, type: :data, as: :own)
+    scoped_users = chat.authorized_scope(users, type: :data, as: :own)
 
     assert_equal 1, scoped_users.size
     assert_equal "admin", scoped_users.first.name
@@ -128,17 +128,17 @@ class TestAuthorizedBehaviour < Minitest::Test
     chat = ChatChannel.new("jack")
 
     assert_raises(ActionPolicy::UnknownScopeType) do
-      chat.authorized(users, type: :users)
+      chat.authorized_scope(users, type: :users)
     end
 
     users.define_singleton_method(:policy_class) { CustomPolicy }
 
-    scoped_users = chat.authorized(users, type: :users)
+    scoped_users = chat.authorized_scope(users, type: :users)
     assert_equal "jack", scoped_users.first.name
 
     chat = ChatChannel.new("admin")
 
-    scoped_users = chat.authorized(users, type: :users)
+    scoped_users = chat.authorized_scope(users, type: :users)
 
     assert_equal 1, scoped_users.size
     assert_equal "admin", scoped_users.first.name

--- a/test/action_policy/rails/scope_matchers_test.rb
+++ b/test/action_policy/rails/scope_matchers_test.rb
@@ -46,11 +46,11 @@ class TestRailsScopeMatchers < ActionController::TestCase
     authorize :user, through: :current_user
 
     def index
-      render json: authorized(AR::User.all)
+      render json: authorized_scope(AR::User.all)
     end
 
     def posts
-      render json: authorized(current_user.posts)
+      render json: authorized_scope(current_user.posts)
     end
 
     def create

--- a/test/action_policy/test_helper_test.rb
+++ b/test/action_policy/test_helper_test.rb
@@ -30,15 +30,15 @@ class TestHelperTest < Minitest::Test
     end
 
     def filter(users)
-      authorized users, type: :data, with: CustomPolicy
+      authorized_scope users, type: :data, with: CustomPolicy
     end
 
     def filter_with_options(users, with_admins: false)
-      authorized users, type: :data, with: CustomPolicy, scope_options: {with_admins: with_admins}
+      authorized_scope users, type: :data, with: CustomPolicy, scope_options: {with_admins: with_admins}
     end
 
     def own(users)
-      authorized users, type: :data, as: :own, with: CustomPolicy
+      authorized_scope users, type: :data, as: :own, with: CustomPolicy
     end
   end
 


### PR DESCRIPTION
## What's inside:
- [x] Renamed `authorized` ->` authorized_scope` (`authorized` alias is also available, no plans on deprecating)
- [x] Made `authorized_scope` to be available within polices (Closes #53)

## PR checklist:

- [x] Tests included
- [x] Documentation updated
- [x] Changelog entry added
