### PR TITLE
docs: fix decorators example not working correctly

### DIFF
--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -15,7 +15,7 @@ module ActionPolicy
   module Draper
     def policy_for(record:, **opts)
       # From https://github.com/GoodMeasuresLLC/draper-cancancan/blob/master/lib/draper/cancancan.rb
-      record = record.model while record.is_a?(Draper::Decorator)
+      record = record.model while record.is_a?(::Draper::Decorator)
       super(record: record, **opts)
     end
   end


### PR DESCRIPTION
The code was trying to look for `ActionPolicy::Draper::Decorator` instead of looking for `Draper::Decorator` at the top level.