### PR TITLE
Update pundit_syntax.rb

### DIFF
--- a/lib/action_policy/rspec/pundit_syntax.rb
+++ b/lib/action_policy/rspec/pundit_syntax.rb
@@ -43,6 +43,6 @@ RSpec.configure do |config|
   config.include(
     ActionPolicy::RSpec::PunditSyntax::PolicyExampleGroup,
     type: :policy,
-    example_group: {file_path: %r{spec/policies}}
+    parent_example_group: {file_path: %r{spec/policies}}
   )
 end

--- a/lib/action_policy/rspec/pundit_syntax.rb
+++ b/lib/action_policy/rspec/pundit_syntax.rb
@@ -43,6 +43,6 @@ RSpec.configure do |config|
   config.include(
     ActionPolicy::RSpec::PunditSyntax::PolicyExampleGroup,
     type: :policy,
-    parent_example_group: {file_path: %r{spec/policies}}
+    file_path: %r{spec/policies}
   )
 end


### PR DESCRIPTION
migrate from deprecated syntax in RSpec

https://github.com/rspec/rspec-core/commit/f3ec09fd2441775c8f73e62b70c4589f5aca0c40

<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->


<!--
  Otherwise, describe the changes: 

### What is the purpose of this pull request?

### What changes did you make? (overview)

### Is there anything you'd like reviewers to focus on?

-->

PR checklist:

- [ ] Tests included
- [ ] Documentation updated
- [ ] Changelog entry added
