### PR TITLE
with_clean_result: reset `@result` with ensure

### DIFF
--- a/lib/action_policy/policy/core.rb
+++ b/lib/action_policy/policy/core.rb
@@ -90,8 +90,9 @@ module ActionPolicy
       def with_clean_result # :nodoc:
         was_result = @result
         yield
-        res, @result = @result, was_result
-        res
+        @result
+      ensure
+        @result = was_result
       end
 
       # Returns a result of applying the specified rule to the specified record.


### PR DESCRIPTION
If the inner block raises an error it was possible that `@result` would
not be reset.