### PR TITLE
allowed_to?: don't lookup policy if record is the same as the current policy

### DIFF
--- a/lib/action_policy/policy/core.rb
+++ b/lib/action_policy/policy/core.rb
@@ -100,7 +100,7 @@ module ActionPolicy
       #
       # If record is `nil` then we uses the current policy.
       def allowed_to?(rule, record = :__undef__, **options)
-        if record == :__undef__ && options.empty?
+        if (record == :__undef__ || record == self.record) && options.empty?
           __apply__(rule)
         else
           policy_for(record: record, **options).apply(rule)

--- a/lib/action_policy/policy/reasons.rb
+++ b/lib/action_policy/policy/reasons.rb
@@ -179,7 +179,7 @@ module ActionPolicy
 
       def allowed_to?(rule, record = :__undef__, **options)
         res =
-          if record == :__undef__
+          if (record == :__undef__ || record == self.record) && options.empty?
             policy = self
             with_clean_result { apply(rule) }
           else


### PR DESCRIPTION
The code already does this when record is not provided as the code treats that
as executing with the same record. In the case where the record is in fact the same
we should run the same code path.