### PR TITLE
Feat: optional authorization context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@
 
   Adds `action_policy:install` and `action_policy:policy MODEL` Rails generators.
 
+- Optional authorization target. ([@somenugget][])
+
+  Allows making authorization context optional:
+  ```ruby
+  class OptionalRolePolicy < ActionPolicy::Base
+    authorize :role, optional: true
+  end
+
+  policy = OptionalRolePolicy.new
+  policy.role #=> nil
+  ```
 ## 0.3.2 (2019-05-26) 👶
 
 - Fixed thread-safety issues with scoping configs. ([@palkan][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -334,3 +334,4 @@
 [@DmitryTsepelev]: https://github.com/DmitryTsepelev
 [@korolvs]: https://github.com/korolvs
 [@nicolas-brousse]: https://github.com/nicolas-brousse
+[@somenugget]: https://github.com/somenugget

--- a/docs/authorization_context.md
+++ b/docs/authorization_context.md
@@ -19,6 +19,7 @@ end
 Now you must provide `account` during policy initialization. When authorization key is missing or equals to `nil`, `ActionPolicy::AuthorizationContextMissing` error is raised.
 
 **NOTE:** if you want to allow passing `nil` as `account` value, you must add `allow_nil: true` option to `authorize`.
+If you want to be able not to pass `account` at all, you must add `optional: true`
 
 To do that automatically in your `authorize!` and `allowed_to?` calls, you must also configure authorization context. For example, in your controller:
 

--- a/lib/action_policy/policy/authorization.rb
+++ b/lib/action_policy/policy/authorization.rb
@@ -50,7 +50,7 @@ module ActionPolicy
 
         self.class.authorization_targets.each do |id, opts|
           if opts[:optional] == true
-            val = nil
+            val = params.fetch(id, nil)
           else
             raise AuthorizationContextMissing, id unless params.key?(id)
 

--- a/lib/action_policy/policy/authorization.rb
+++ b/lib/action_policy/policy/authorization.rb
@@ -49,11 +49,15 @@ module ActionPolicy
         @authorization_context = {}
 
         self.class.authorization_targets.each do |id, opts|
-          raise AuthorizationContextMissing, id unless params.key?(id)
+          if opts[:optional] == true
+            val = nil
+          else
+            raise AuthorizationContextMissing, id unless params.key?(id)
 
-          val = params.fetch(id)
+            val = params.fetch(id)
 
-          raise AuthorizationContextMissing, id if val.nil? && opts[:allow_nil] != true
+            raise AuthorizationContextMissing, id if val.nil? && opts[:allow_nil] != true
+          end
 
           authorization_context[id] = instance_variable_set("@#{id}", val)
         end

--- a/test/action_policy/policy/authorization_test.rb
+++ b/test/action_policy/policy/authorization_test.rb
@@ -12,6 +12,13 @@ class SubAuthorizeTestPolicy < AuthorizeTestPolicy
   authorize :role, allow_nil: true
 end
 
+class OptionalRoleTestPolicy
+  include ActionPolicy::Policy::Core
+  include ActionPolicy::Policy::Authorization
+
+  authorize :role, optional: true
+end
+
 class AuthorizationTest < Minitest::Test
   def test_target_is_missing
     e = assert_raises ActionPolicy::AuthorizationContextMissing do
@@ -47,6 +54,11 @@ class AuthorizationTest < Minitest::Test
   def test_context_allow_nil
     policy = SubAuthorizeTestPolicy.new(account: "EvilMartians", role: nil)
     assert_equal "EvilMartians", policy.account
+    assert_nil policy.role
+  end
+
+  def test_context_optional
+    policy = OptionalRoleTestPolicy.new
     assert_nil policy.role
   end
 end

--- a/test/action_policy/policy/authorization_test.rb
+++ b/test/action_policy/policy/authorization_test.rb
@@ -61,6 +61,11 @@ class AuthorizationTest < Minitest::Test
     policy = OptionalRoleTestPolicy.new
     assert_nil policy.role
   end
+
+  def test_context_optional_with_value
+    policy = OptionalRoleTestPolicy.new(role: "human")
+    assert_equal "human", policy.role
+  end
 end
 
 class ProxyAuthorizationToSubPoliciesTest < Minitest::Test


### PR DESCRIPTION
### What is the purpose of this pull request?
As suggested in https://github.com/palkan/action_policy/issues/89#issuecomment-557717110
it allows making authorization context optional

### What changes did you make? (overview)
Don't raise `AuthorizationContextMissing` from `ActionPolicy::Policy::Authorization` if authorization target was defined with has `optional: true`

PR checklist:

- [x] Tests included
- [x] Documentation updated
- [x] Changelog entry added
