### PR TITLE
Improve caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+- Handle versioned Rails cache keys. ([@palkan][])
+
+  Use `#cache_with_version` as a cache key if defined.
+
 ## 0.4.2 (2019-12-13)
 
 - Fix regression introduced in 0.4.0 which broke testing Class targets. ([@palkan][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master
 
+- Add `#cache(*parts, **options) { ... }` method. ([@palkan][])
+
+  Allows you to cache anything in policy classes using the Action Policy
+  cache key generation mechanism.
+
 - Handle versioned Rails cache keys. ([@palkan][])
 
   Use `#cache_with_version` as a cache key if defined.

--- a/lib/action_policy/ext/policy_cache_key.rb
+++ b/lib/action_policy/ext/policy_cache_key.rb
@@ -13,6 +13,7 @@ module ActionPolicy
       module ObjectExt
         def _policy_cache_key(use_object_id: false)
           return policy_cache_key if respond_to?(:policy_cache_key)
+          return cache_key_with_version if respond_to?(:cache_key_with_version)
           return cache_key if respond_to?(:cache_key)
 
           return object_id if use_object_id == true

--- a/lib/action_policy/ext/policy_cache_key.rb
+++ b/lib/action_policy/ext/policy_cache_key.rb
@@ -16,7 +16,7 @@ module ActionPolicy
           return cache_key_with_version if respond_to?(:cache_key_with_version)
           return cache_key if respond_to?(:cache_key)
 
-          return object_id if use_object_id == true
+          return object_id.to_s if use_object_id == true
 
           raise ArgumentError, "object is not cacheable"
         end
@@ -84,6 +84,12 @@ module ActionPolicy
       refine Time do
         def _policy_cache_key(*)
           to_s
+        end
+      end
+
+      refine Module do
+        def _policy_cache_key(*)
+          name
         end
       end
     end

--- a/lib/action_policy/ext/policy_cache_key.rb
+++ b/lib/action_policy/ext/policy_cache_key.rb
@@ -22,11 +22,6 @@ module ActionPolicy
         end
       end
 
-      # JRuby doesn't support _global_ modules refinements (see https://github.com/jruby/jruby/issues/5220)
-      # Fallback to monkey-patching.
-      # TODO: remove after 9.2.7.0 (See https://github.com/jruby/jruby/pull/5627)
-      ::Object.include(ObjectExt) if RUBY_PLATFORM =~ /java/i
-
       refine Object do
         include ObjectExt
       end

--- a/test/action_policy/ext/policy_cache_key_test.rb
+++ b/test/action_policy/ext/policy_cache_key_test.rb
@@ -32,7 +32,7 @@ class TestPolicyCacheKey < Minitest::Test
   def test_object_id_fallback
     obj = Base.new
 
-    assert_equal obj.object_id, obj._policy_cache_key(use_object_id: true)
+    assert_equal obj.object_id.to_s, obj._policy_cache_key(use_object_id: true)
   end
 
   def test_raise_without_fallback

--- a/test/action_policy/rails/active_record_helper.rb
+++ b/test/action_policy/rails/active_record_helper.rb
@@ -24,12 +24,18 @@ ActiveRecord::Schema.define do
   end
 end
 
+ActiveRecord::Base.cache_versioning = true if ActiveRecord::Base.respond_to?(:cache_versioning)
+
 module AR
   class User < ActiveRecord::Base
     has_many :posts, foreign_key: :user_id, class_name: "AR::Post"
 
     def self.policy_name
       "UserPolicy"
+    end
+
+    def admin?
+      role == "admin"
     end
   end
 

--- a/test/action_policy/rails/cache_test.rb
+++ b/test/action_policy/rails/cache_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "active_record_helper"
+require "stubs/in_memory_cache"
+
+class TestRailsPolicyCache < Minitest::Test
+  class UserPolicy < ActionPolicy::Base
+    authorize :user
+
+    class << self
+      attr_accessor :managed_count
+
+      def reset
+        @managed_count = 0
+      end
+    end
+
+    reset
+
+    authorize :user
+
+    cache :manage?
+
+    def manage?
+      self.class.managed_count += 1
+
+      user.admin? && !record.admin?
+    end
+  end
+
+  def setup
+    ActiveRecord::Base.connection.begin_transaction(joinable: false)
+    ActionPolicy.cache_store = InMemoryCache.new
+    @guest = AR::User.create!(role: "guest")
+  end
+
+  attr_reader :guest
+
+  def teardown
+    UserPolicy.reset
+    ActionPolicy.cache_store = nil
+    ActiveRecord::Base.connection.rollback_transaction
+  end
+
+  def test_cache_with_versioning
+    user = AR::User.create!(role: "admin")
+
+    policy = UserPolicy.new guest, user: user
+
+    assert policy.apply(:manage?)
+    assert policy.apply(:manage?)
+
+    assert_equal 1, UserPolicy.managed_count
+
+    policy_2 = UserPolicy.new guest, user: user
+
+    assert policy_2.apply(:manage?)
+
+    assert_equal 1, UserPolicy.managed_count
+
+    user.touch
+
+    policy_3 = UserPolicy.new guest, user: user
+
+    assert policy_3.apply(:manage?)
+
+    assert_equal 2, UserPolicy.managed_count
+
+    guest.touch
+
+    policy_4 = UserPolicy.new guest, user: user
+
+    assert policy_4.apply(:manage?)
+
+    assert_equal 3, UserPolicy.managed_count
+  end
+end


### PR DESCRIPTION
### What changes did you make? (overview)

- [x] Use `#cache_with_version` as a cache key if defined.

- [x] Add `#cache(*parts, **options) { ... }` method. 

Allows you to cache anything in policy classes using the Action Policy cache key generation mechanism.

### PR checklist:

- [x] Tests included
- [x] Documentation updated
- [x] Changelog entry added
