### PR TITLE
Add reason set feature for handling failure reasons.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Add reason_set feature for handling failure reasons. (@ykpythemind)
+
 ## 0.4.5 (2020-07-29)
 
 - Add strict_namespace option to lookup chain. (@rainerborene)

--- a/test/action_policy/policy/reasons_test.rb
+++ b/test/action_policy/policy/reasons_test.rb
@@ -153,6 +153,17 @@ class TestFailuresWithDetailsPolicy < Minitest::Test
       details[:superhero] = "spiderman"
       false
     end
+
+    def player?
+      reason_set << :invalid_player
+      false
+    end
+  end
+
+  class PlayerPolicy < ActionPolicy::Base
+    def run?
+      allowed_to?(:player?, user)
+    end
   end
 
   def test_and_condition_nested_check_details
@@ -190,5 +201,19 @@ class TestFailuresWithDetailsPolicy < Minitest::Test
     assert_equal({
       detailed: [{kill?: {role: "admin"}, feed?: {some: "stuff"}}]
     }, details)
+  end
+
+  def test_result_set
+    policy = UserPolicy.new user: User.new("guest")
+    refute policy.apply(:player?)
+
+    assert policy.result.reasons.set.include?(:invalid_player)
+  end
+
+  def test_nested_policy_result_set
+    policy = PlayerPolicy.new user: User.new("guest")
+    refute policy.apply(:run?)
+
+    assert policy.result.reasons.set.include?(:invalid_player)
   end
 end


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

### What is the purpose of this pull request?

I want to provide additional failure reasons for later error handling.

For example, if you use ActiveRecord::RecordNotFound exception, any unauthorized user will recognize `post` is not found.

```ruby
post = current_user.posts.published.find(params[:id]) # => raise ActiveRecord::RecordNotFound
```

But sometimes, you may pass `post` directly into the policy.

```ruby
class PostPolicy < ApplicationPolicy
  def edit?
    record.published?
  end
end

post = find_post_by_some_complex_logic
allowed_to?(:edit?, post)
```

In this case, you want to handle `ActionPolicy::Unauthorized` as `NotFound`, not `Forbidden` because user infer `post.id` is present.

So, `reason_set` is useful.

```ruby
class PostPolicy < ApplicationPolicy
  def edit?
    published?
  end

  private

  def published?
    reason_set << :unpublished
    record.published?
  end
end

class ApplicationController < ActionController::Base
  rescue_from ActionPolicy::Unauthorized do |ex|
    p ex.result.reasons.set #=> #<Set: {:unpublished}>

    # You can handle this reason as `NotFound`.
    if ex.result.reasons.set.include?(:unpublished)
      head :not_found
    else
      head :forbidden
    end
  end
end
```

### What changes did you make? (overview)

- I added `set` to store reason (or context).

### Is there anything you'd like reviewers to focus on?

- grammar in documents ( I'm not good at English)
- method name

PR checklist:

- [x] Tests included
- [x] Documentation updated
- [x] Changelog entry added
