### PR TITLE
Move deny!/allow! to core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## master
 
+- Move `deny!` / `allow!` to core. ([@palkan][])
+
+Now you can call `deny!` and `allow!` in policy rules to fail- or pass-fast.
+
+**BREAKING.** Pre-check name is no longer added automatically to failure reasons. You should specify the reason
+explicitly: `deny!(:my_reason)`.
+
 - Add `Result#all_details` to return all collected details in a single hash. ([@palkan][])
 
 - Add `default` option to lookup and `default_authorization_policy_class` callback to behaviour. ([@palkan][])

--- a/benchmarks/catch_throw.rb
+++ b/benchmarks/catch_throw.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# This benchmark measures the difference between catch/throw and jump-less implementation.
+
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+
+require "action_policy"
+require "benchmark/ips"
+
+GC.disable
+
+class A; end
+
+class B; end
+
+class APolicy < ActionPolicy::Base
+  authorize :user, optional: true
+
+  def apply(rule)
+    @result = self.class.result_class.new(self.class, rule)
+    @result.load __apply__(rule)
+  end
+
+  def show?
+    true
+  end
+end
+
+class BPolicy < ActionPolicy::Base
+  authorize :user, optional: true
+
+  def apply(rule)
+    @result = self.class.result_class.new(self.class, rule)
+
+    catch :throw_me_away do
+      @result.load __apply__(rule)
+    end
+
+    @result.value
+  end
+
+  def show?
+    @result.load true
+
+    throw :throw_me_away
+  end
+end
+
+a = A.new
+
+(APolicy.new(record: a).apply(:show?) == BPolicy.new(record: a).apply(:show?)) || raise("Implementations are not equal")
+
+Benchmark.ips do |x|
+  x.warmup = 0
+
+  x.report("no catch/throw") do
+    APolicy.new(record: a).apply(:show?)
+  end
+
+  x.report("with catch/throw") do
+    BPolicy.new(record: a).apply(:show?)
+  end
+
+  x.compare!
+end

--- a/docs/reasons.md
+++ b/docs/reasons.md
@@ -54,6 +54,20 @@ p ex.result.reasons.details #=> { applicant: [:view_applicants?] }
 p ex.result.reasons.details #=> { stage: [:show?] }
 ```
 
+Reason could also be specified for `deny!` calls:
+
+```ruby
+class TeamPolicy < ApplicationPolicy
+  def show?
+    deny!(:no_user) if user.anonymous?
+
+    user.has_permission?(:view_teams)
+  end
+end
+
+p ex.result.reasons.details #=> { applicant: [:no_user] }
+```
+
 ## Detailed Reasons
 
 You can provide additional details to your failure reasons by using a `details: { ... }` option:

--- a/docs/writing_policies.md
+++ b/docs/writing_policies.md
@@ -70,6 +70,26 @@ end
 
 \* It's not a Ruby _alias_ but a wrapper; we can't use `alias` or `alias_method`, 'cause `allowed_to?` could be extended by some extensions.
 
+## Fail-fast or pass-fast
+
+For better readability, we provide an alternative API (originally introduced for [pre-checks](./pre_checks.md)) to allow or deny a particular action. There are two methods—`allow!` and `deny!`:
+
+```ruby
+class PostPolicy < ApplicationPolicy
+  def show?
+    allow! if user.admin?
+
+    check?(:publicly_visible?)
+  end
+
+  def destroy?
+    deny! if record.subscribers.any?
+
+    # some general logic
+  end
+end
+```
+
 ## Identifiers
 
 Each policy class has an `identifier`, which is by default just an underscored class name:

--- a/lib/action_policy/policy/core.rb
+++ b/lib/action_policy/policy/core.rb
@@ -77,7 +77,22 @@ module ActionPolicy
       # `apply` also calls pre-checks.
       def apply(rule)
         @result = self.class.result_class.new(self.class, rule)
-        @result.load __apply__(rule)
+
+        catch :policy_fulfilled do
+          result.load __apply__(rule)
+        end
+
+        result.value
+      end
+
+      def deny!
+        result&.load false
+        throw :policy_fulfilled
+      end
+
+      def allow!
+        result&.load true
+        throw :policy_fulfilled
       end
 
       # This method performs the rule call.

--- a/lib/action_policy/policy/reasons.rb
+++ b/lib/action_policy/policy/reasons.rb
@@ -206,6 +206,11 @@ module ActionPolicy
 
         res.success?
       end
+
+      def deny!(reason = nil)
+        result&.reasons&.add(self, reason) if reason
+        super()
+      end
     end
   end
 end

--- a/test/action_policy/policy/core_test.rb
+++ b/test/action_policy/policy/core_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CoreTestPolicy
+  include ActionPolicy::Policy::Core
+
+  def index?
+    true
+  end
+
+  def update?
+    allow! if record[:editable]
+    false
+  end
+
+  def destroy?
+    deny! if record[:undeletable]
+    true
+  end
+end
+
+class TestPolicyCore < Minitest::Test
+  def setup
+    @record = {}
+    @policy = CoreTestPolicy.new @record
+  end
+
+  def test_apply
+    assert @policy.apply(:index?)
+    refute @policy.apply(:update?)
+    assert @policy.apply(:destroy?)
+  end
+
+  def test_allow_deny
+    @record[:undeletable] = true
+    @record[:editable] = true
+
+    assert @policy.apply(:update?)
+    refute @policy.apply(:destroy?)
+  end
+end

--- a/test/action_policy/policy/pre_check_test.rb
+++ b/test/action_policy/policy/pre_check_test.rb
@@ -139,6 +139,10 @@ class TestPreCheck < Minitest::Test
     include ActionPolicy::Policy::Reasons
 
     self.identifier = :reasons
+
+    def user_is_nil
+      deny!(:no_user) if user.name == "Neil"
+    end
   end
 
   def test_pre_check_with_reasons
@@ -146,6 +150,6 @@ class TestPreCheck < Minitest::Test
 
     refute policy.apply(:index?)
 
-    assert_equal({reasons: [:user_is_nil]}, policy.result.reasons.details)
+    assert_equal({reasons: [:no_user]}, policy.result.reasons.details)
   end
 end

--- a/test/action_policy/policy/reasons_test.rb
+++ b/test/action_policy/policy/reasons_test.rb
@@ -47,6 +47,10 @@ class ComplexFailuresTestPolicy < ActionPolicy::Base
   def feed?
     false
   end
+
+  def sing?
+    deny!(:no_singing_today)
+  end
 end
 
 class TestComplexFailuresPolicy < Minitest::Test
@@ -107,6 +111,18 @@ class TestComplexFailuresPolicy < Minitest::Test
 
     refute policy.save?
     assert_nil policy.result
+  end
+
+  def test_deny
+    policy = ComplexFailuresTestPolicy.new user: User.new("guest")
+
+    refute policy.apply(:sing?)
+
+    details = policy.result.reasons.details
+
+    assert_equal({
+      complex: [:no_singing_today]
+    }, details)
   end
 end
 


### PR DESCRIPTION
### What is the purpose of this pull request?

Make `allow!` and `deny!` available in policy rules.

Closes #120.

### What changes did you make? (overview)

- [x] Refactored `#apply` internals to use catch-throw for fail- or pass-fast
- [x] Moved `deny!` and `allow!` too Core.

### Is there anything you'd like reviewers to focus on?

PR checklist:

- [x] Tests included
- [x] Documentation updated
- [x] Changelog entry added
