### PR TITLE
Fix global policies not being found with `strict_namespace: true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Add support for RSpec aliases detection when linting policy specs with `rubocop-rspec` 2.0 ([@pirj][])
 
+- Fix `strict_namespace: true` lookup option not finding policies in global namespace ([@Be-ngt-oH][])
+
 ## 0.5.0 (2020-09-29)
 
 - Move `deny!` / `allow!` to core. ([@palkan][])
@@ -39,7 +41,7 @@ This method is similar to `allowed_to?` but returns an authorization result obje
 
 Fixes [#122](https://github.com/palkan/action_policy/issues/122).
 
-- Separated `#classify`-based and `#camelize`-based symbol lookups. ([Be-ngt-oH][])
+- Separated `#classify`-based and `#camelize`-based symbol lookups. ([@Be-ngt-oH][])
 
 Only affects Rails apps. Now lookup for `:users` tries to find `UsersPolicy` first (camelize),
 and only then search for `UserPolicy` (classify).

--- a/lib/action_policy/lookup_chain.rb
+++ b/lib/action_policy/lookup_chain.rb
@@ -36,8 +36,7 @@ module ActionPolicy
           if strict
             put_if_absent(:strict, namespace, policy, &block)
           else
-            cached_policy = put_if_absent(:strict, namespace, policy, &block)
-            put_if_absent(:flexible, namespace, policy) { cached_policy }
+            put_if_absent(:flexible, namespace, policy, &block)
           end
         end
 

--- a/test/action_policy/lookup_chain_test.rb
+++ b/test/action_policy/lookup_chain_test.rb
@@ -146,6 +146,26 @@ class TestLookupChain < Minitest::Test
     )
   end
 
+  def test_lookup_namespace_strict
+    assert_raises(ActionPolicy::NotFound) do
+      ActionPolicy.lookup(:lookup_a, namespace: LookupNamespace::NestedNamespace, strict_namespace: true)
+    end
+
+    assert_equal(
+      LookupNamespace::LookupAPolicy,
+      ActionPolicy.lookup(:lookup_a, namespace: LookupNamespace, strict_namespace: true)
+    )
+
+    assert_raises(ActionPolicy::NotFound) do
+      ActionPolicy.lookup(:lookup_b, namespace: LookupNamespace, strict_namespace: true)
+    end
+
+    assert_equal(
+      LookupBPolicy,
+      ActionPolicy.lookup(:lookup_b, strict_namespace: true)
+    )
+  end
+
   def test_namespace_cache_strategy
     ActionPolicy::LookupChain.namespace_cache_enabled = true
     ActionPolicy::LookupChain::NamespaceCache.clear

--- a/test/action_policy/lookup_chain_test.rb
+++ b/test/action_policy/lookup_chain_test.rb
@@ -157,12 +157,14 @@ class TestLookupChain < Minitest::Test
     assert_nil store.dig(:flexible, LookupNamespace.name, LookupAPolicy.name)
 
     ActionPolicy.lookup(:lookup_a, namespace: LookupNamespace)
+    ActionPolicy.lookup(:lookup_a, namespace: LookupNamespace, strict_namespace: true)
 
     # cache stored
     assert_equal LookupNamespace::LookupAPolicy, store.dig(:strict, LookupNamespace.name, LookupAPolicy.name)
     assert_equal LookupNamespace::LookupAPolicy, store.dig(:flexible, LookupNamespace.name, LookupAPolicy.name)
 
     # return cached policy
+    assert_equal LookupNamespace::LookupAPolicy, ActionPolicy.lookup(:lookup_a, namespace: LookupNamespace)
     assert_equal LookupNamespace::LookupAPolicy, ActionPolicy.lookup(:lookup_a, namespace: LookupNamespace, strict_namespace: true)
 
     # should respect cascade search


### PR DESCRIPTION
Hello,

We recently looked at enabling the strict_namespace option globally to ensure people are adding new policies in a particular namespace. Unfortunately we couldn't because it'd break the lookup in other areas. Here's the commit description:

---

Previously, we'd skip some lookups when `namespace` was nil and others when `strict` was true. This resulted in a situation where you'd not find a non-namespaced `ThingPolicy` when using the lookup with `strict_namespace: true`.

With the changes of this commit, the lookup will start finding `ThingPolicy` in strict mode if and only if the authorisation namespace is nil.

---

I _think_ the previous behaviour was buggy and not documented so I wouldn't consider it to be a breaking change. The change also allows us to simplify the lookup code a little bit. I hope it's cool - looking forward to your review!

PR checklist:

- [x] Tests included
- [ ] ~Documentation updated~
- [x] Changelog entry added
