### PR TITLE
allow marking authorize! to skip counting for verify_authorized

### DIFF
--- a/lib/action_policy/rails/controller.rb
+++ b/lib/action_policy/rails/controller.rb
@@ -42,12 +42,12 @@ module ActionPolicy
     # from controller name (i.e. `controller_name.classify.safe_constantize`).
     #
     # Raises `ActionPolicy::Unauthorized` if check failed.
-    def authorize!(record = :__undef__, to: nil, **options)
+    def authorize!(record = :__undef__, to: nil, skip_count: false, **options)
       to ||= :"#{action_name}?"
 
       super(record, to: to, **options)
 
-      self.authorize_count += 1
+      self.authorize_count += 1 unless skip_count
     end
 
     # Tries to infer the resource class from controller name


### PR DESCRIPTION
It turns out that there is a need to do general `authorize!` for lets say Account then per method.
`verify_authorized` is counting just one call. After few workarounds it was decided to just add optional flag for `authorize!` to skip counting in `authorize_count`.
Like that: `before_action -> { authorize!(c_camp, to: :show?, skip_count: true)`

If this PR makes sense I will add test and docs/changelog entry

<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->


<!--
  Otherwise, describe the changes: 

### What is the purpose of this pull request?

### What changes did you make? (overview)

### Is there anything you'd like reviewers to focus on?

-->

PR checklist:

- [ ] Tests included
- [ ] Documentation updated
- [ ] Changelog entry added
