### PR TITLE
ActionController::API should include ActionPolicy::Controller

### DIFF
--- a/lib/action_policy/railtie.rb
+++ b/lib/action_policy/railtie.rb
@@ -87,6 +87,10 @@ module ActionPolicy # :nodoc:
 
         ActionController::Base.include ActionPolicy::Controller
 
+        if ::Rails::VERSION::MAJOR >= 5
+          ActionController::API.include ActionPolicy::Controller
+        end
+
         next unless ::Rails.application.config.action_policy.controller_authorize_current_user
 
         ActionController::Base.authorize :user, through: :current_user

--- a/test/action_policy/rails/railtie_test.rb
+++ b/test/action_policy/rails/railtie_test.rb
@@ -13,6 +13,10 @@ class TestRailtie < Minitest::Test
   def test_default_configuration
     assert(ActionController::Base <= ActionPolicy::Controller, "#{ActionController::Base.ancestors} must include ActionPolicy::Controller")
 
+    if ::Rails::VERSION::MAJOR >= 5
+      assert(ActionController::API <= ActionPolicy::Controller, "#{ActionController::API.ancestors} must include ActionPolicy::Controller")
+    end
+
     assert_equal({user: :current_user}, ActionController::Base.authorization_targets)
 
     refute ActionPolicy::LookupChain.namespace_cache_enabled?


### PR DESCRIPTION
### What is the purpose of this pull request?

I want to use `authorized_scope` `authorize!` methods in inheritance of ActionController::API

### What changes did you make? (overview)

I fixed railtie.rb

### Is there anything you'd like reviewers to focus on?

PR checklist:

- [x] Tests included
- [ ] Documentation updated
- [x] Changelog entry added
