### PR TITLE
Add `ActionPolicy.enforce_predicate_rules_naming` config 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Add `ActionPolicy.enforce_predicate_rules_naming` config to catch rule missing question mark ([@skojin][])
+
 ## 0.5.5 (2020-12-28)
 
 - Upgrade to Ruby 3.0. ([@palkan][])

--- a/docs/aliases.md
+++ b/docs/aliases.md
@@ -57,6 +57,10 @@ Now when you call `authorize! post` with any rule not defined in the policy clas
 
 By default, `ActionPolicy::Base` sets `manage?` as a default rule.
 
+## Mistypes & Default
+
+In case you forget to add `?` at the end of `:new` in a code like `allowed_to?(:new, User)`, a wrong rule will be called. Instead of the`:new?`, the `:manage?` rule will be applied. You can set `ActionPolicy.enforce_predicate_rules_naming = true` to raise an error when the called rule doesn't end with a question mark.
+
 ## Aliases and Private Methods
 
 Rules in `action_policy` can only be public methods. Trying to use a private method as a rule will raise an error. Thus, aliases can also only point to public methods.

--- a/lib/action_policy.rb
+++ b/lib/action_policy.rb
@@ -34,6 +34,8 @@ module ActionPolicy
   class << self
     attr_accessor :cache_store
 
+    attr_accessor :enforce_predicate_rules_naming
+
     # Find a policy class for a target
     def lookup(target, allow_nil: false, default: nil, **options)
       LookupChain.call(target, **options) ||

--- a/lib/action_policy/policy/aliases.rb
+++ b/lib/action_policy/policy/aliases.rb
@@ -31,8 +31,16 @@ module ActionPolicy
       def resolve_rule(activity)
         self.class.lookup_alias(activity) ||
           (activity if respond_to?(activity)) ||
+          (check_rule_naming(activity) if ActionPolicy.enforce_predicate_rules_naming) ||
           self.class.lookup_default_rule ||
           super
+      end
+
+      private def check_rule_naming(activity)
+        unless activity[-1] == "?"
+          raise UnknownRule.new(self, activity, "The rule '#{activity}' of '#{self.class}' must ends with ? (question mark)")
+        end
+        nil
       end
 
       module ClassMethods # :nodoc:

--- a/lib/action_policy/policy/aliases.rb
+++ b/lib/action_policy/policy/aliases.rb
@@ -38,7 +38,7 @@ module ActionPolicy
 
       private def check_rule_naming(activity)
         unless activity[-1] == "?"
-          raise UnknownRule.new(self, activity, "The rule '#{activity}' of '#{self.class}' must ends with ? (question mark)")
+          raise NonPredicateRule.new(self, activity)
         end
         nil
       end

--- a/lib/action_policy/policy/core.rb
+++ b/lib/action_policy/policy/core.rb
@@ -20,10 +20,10 @@ module ActionPolicy
 
     attr_reader :policy, :rule, :message
 
-    def initialize(policy, rule)
+    def initialize(policy, rule, message = nil)
       @policy = policy.class
       @rule = rule
-      @message =
+      @message = message ||
         "Couldn't find rule '#{@rule}' for #{@policy}" \
         "#{suggest(@rule, @policy.instance_methods - Object.instance_methods)}"
     end

--- a/lib/action_policy/policy/core.rb
+++ b/lib/action_policy/policy/core.rb
@@ -20,12 +20,19 @@ module ActionPolicy
 
     attr_reader :policy, :rule, :message
 
-    def initialize(policy, rule, message = nil)
+    def initialize(policy, rule)
       @policy = policy.class
       @rule = rule
-      @message = message ||
-        "Couldn't find rule '#{@rule}' for #{@policy}" \
+      @message = "Couldn't find rule '#{@rule}' for #{@policy}" \
         "#{suggest(@rule, @policy.instance_methods - Object.instance_methods)}"
+    end
+  end
+
+  class NonPredicateRule < UnknownRule
+    def initialize(policy, rule)
+      @policy = policy.class
+      @rule = rule
+      @message = "The rule '#{@rule}' of '#{@policy}' must ends with ? (question mark)\nDid you mean? #{@rule}?"
     end
   end
 

--- a/test/action_policy/policy/enforce_predicate_rules_naming_test.rb
+++ b/test/action_policy/policy/enforce_predicate_rules_naming_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DefaultsTestPolicy < ActionPolicy::Base
+end
+
+class TestPolicyWithInvalidRuleName < Minitest::Test
+  def setup
+    ActionPolicy.enforce_predicate_rules_naming = true
+    @policy = DefaultsTestPolicy.new user: User.new("john")
+  end
+
+  def teardown
+    ActionPolicy.enforce_predicate_rules_naming = nil
+  end
+
+  def test_good_named_rule
+    assert_equal :manage?, @policy.resolve_rule(:good?)
+  end
+
+  def test_bad_named_rule_without_question
+    assert_raises(ActionPolicy::UnknownRule) do
+      @policy.resolve_rule(:bad)
+    end
+  end
+end

--- a/test/action_policy/policy/enforce_predicate_rules_naming_test.rb
+++ b/test/action_policy/policy/enforce_predicate_rules_naming_test.rb
@@ -20,8 +20,10 @@ class TestPolicyWithInvalidRuleName < Minitest::Test
   end
 
   def test_bad_named_rule_without_question
-    assert_raises(ActionPolicy::UnknownRule) do
+    e = assert_raises(ActionPolicy::NonPredicateRule) do
       @policy.resolve_rule(:bad)
     end
+    assert_includes e.message, "must ends with"
+    assert_includes e.message, "Did you mean? bad?"
   end
 end


### PR DESCRIPTION
to catch the rule missing question mark. 

Fixes #139

PR checklist:

- [x ] Tests included
- [ x] Documentation updated
- [ x] Changelog entry added