### PR TITLE
Allow a proc to be provided for the authorization context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- A proc can now be used to assign the authorization context.
+
 ## 0.5.7 (2021-03-03)
 
 The previous release had incorrect dependencies (due to the missing transpiled files).

--- a/docs/authorization_context.md
+++ b/docs/authorization_context.md
@@ -48,6 +48,9 @@ class ApplicationController < ActionController::Base
   # get the required context object
   # (equals to the context name itself by default, i.e. `account`)
   authorize :account, through: :current_account
+
+  # You can also specify a proc to assign the context.
+  authorize :team, through: -> { @team }
 end
 ```
 

--- a/lib/action_policy/behaviour.rb
+++ b/lib/action_policy/behaviour.rb
@@ -63,7 +63,11 @@ module ActionPolicy
 
       @__authorization_context = self.class.authorization_targets
         .each_with_object({}) do |(key, meth), obj|
-        obj[key] = send(meth)
+          if meth.is_a?(Proc)
+            obj[key] = instance_exec(&meth)
+          else
+            obj[key] = send(meth)
+          end
       end
     end
 

--- a/lib/action_policy/behaviour.rb
+++ b/lib/action_policy/behaviour.rb
@@ -63,11 +63,11 @@ module ActionPolicy
 
       @__authorization_context = self.class.authorization_targets
         .each_with_object({}) do |(key, meth), obj|
-          if meth.is_a?(Proc)
-            obj[key] = instance_exec(&meth)
-          else
-            obj[key] = send(meth)
-          end
+        obj[key] = if meth.is_a?(Proc)
+          instance_exec(&meth)
+        else
+          send(meth)
+        end
       end
     end
 

--- a/test/action_policy/rails/controllers_test.rb
+++ b/test/action_policy/rails/controllers_test.rb
@@ -8,6 +8,31 @@ if ActionPack.version.release < Gem::Version.new("5")
   using ControllerRails4
 end
 
+class TestContextThroughProcIntegration < ActionController::TestCase
+  class UsersController < ActionController::Base
+    authorize :user, through: -> { @user }
+    before_action :set_user
+
+    def index
+      authorize!
+      render plain: "OK"
+    end
+
+    private
+
+    def set_user
+      @user = User.new(params[:user])
+    end
+  end
+
+  tests UsersController
+
+  def test_index
+    get :index, params: {subject: "pete"}
+    assert_equal "OK", response.body
+  end
+end
+
 class TestSimpleControllerIntegration < ActionController::TestCase
   class UsersController < ActionController::Base
     authorize :user, through: :current_user


### PR DESCRIPTION
Thanks for building ActionPolicy! During our search for a simple down to earth authorization policy we wanted to use Pundit, but ran into the same limitations you described, especially context. ActionPolicy solves all our problems so far :)

### What is the purpose of this pull request?
Assigning the authorization context through a method works in a lot of cases, but in some cases you might want to do a little bit different, like using a controller instance variable for the context. In those cases it's not sufficient to specify a method that can be invoked for the authorization context, but you would need a proc to access that variable so that you can do something like this:

```ruby
class SomeController < ApplicationController
  authorize :subject, through: -> { @subject }

  before_action do
    @subject = Subject.find(params[:subject_id])
  end

  def index
    authorize!
    render plain: "Well hello there"
  end
end
```

### What changes did you make? (overview)
I adjusted `authorization_context` in `behaviour.rb` to detect whether a proc was provided for the authorization context. If it's not a proc, behaviour remains unchanged.

### Is there anything you'd like reviewers to focus on?

PR checklist:
- [x] Tests included
- [x] Documentation updated
- [x] Changelog entry added
