### PR TITLE
Prevent possible side effects in policy lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 - Add `strict_namespace:` option to policy_for behaviour ([@kevynlebouille][])
+- Prevent possible side effects in policy lookup ([@tomdalling][])
 
 ## 0.5.7 (2021-03-03)
 
@@ -451,3 +452,4 @@ This value is now stored in a cache (if any) instead of just the call result (`t
 [@Be-ngt-oH]: https://github.com/Be-ngt-oH
 [@pirj]: https://github.com/pirj
 [@skojin]: https://github.com/skojin
+[@tomdalling]: https://github.com/tomdalling

--- a/lib/action_policy/behaviour.rb
+++ b/lib/action_policy/behaviour.rb
@@ -74,7 +74,7 @@ module ActionPolicy
     end
 
     def lookup_authorization_policy(record, **options) # :nodoc:
-      record = implicit_authorization_target! if record == :__undef__
+      record = implicit_authorization_target! if :__undef__ == record
       raise ArgumentError, "Record must be specified" if record.nil?
 
       options[:context] && (options[:context] = authorization_context.merge(options[:context]))


### PR DESCRIPTION
When comparing a `record` to a special symbol, it's safer to do `:__undef__ == record` than to do `record == :__undef__`. This is because `Symbol#==` is more reliable than the polymorphic `#==` method on `record`, which could do anything.

One example of this is [`ActiveRecord::AssociationRelation#==`](https://github.com/rails/rails/blob/070d4afacd3e9721b7e3a4634e4d026b5fa2c32c/activerecord/lib/active_record/association_relation.rb#L14), which has the unwanted side effect of executing a database query if it is passed in to ActionPolicy as the `record` argument.

Fixes #179

PR checklist:

- [x] Shouldn't need tests, because it doesn't really change the logic
- [x] Shouldn't need documentation
- [x] Changelog entry added
