### PR TITLE
Add inline_reasons option to allowed_to?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## master
 
-- [Fix [#173](https://github.com/palkan/action_policy/issues/173)] Explicit context were not merged with implicit one within policy classes. ([@palkan][])
+- [Closes [#186](https://github.com/palkan/action_policy/issues/186)] Add `inline_reasons: true` option to `allowed_to?` to avoid wrapping reasons. ([@palkan][])
+- [Fixes [#173](https://github.com/palkan/action_policy/issues/173)] Explicit context were not merged with implicit one within policy classes. ([@palkan][])
 - Add `strict_namespace:` option to policy_for behaviour ([@kevynlebouille][])
 - Prevent possible side effects in policy lookup ([@tomdalling][])
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -15,4 +15,4 @@ pre-commit:
     rubocop:
       tags: style
       glob: "**/*.md"
-      run: BUNDLE_GEMFILE=gemfiles/rubocop.gemfile bundle exec rubocop -c .rubocop-md.yml {staged_files}
+      run: bundle exec rubocop -c .rubocop-md.yml {staged_files}

--- a/lib/action_policy/policy/core.rb
+++ b/lib/action_policy/policy/core.rb
@@ -133,7 +133,7 @@ module ActionPolicy
       end
 
       # An alias for readability purposes
-      def check?(*args) = allowed_to?(*args)
+      def check?(*args, **hargs) = allowed_to?(*args, **hargs)
 
       # Returns a rule name (policy method name) for activity.
       #


### PR DESCRIPTION
### What is the purpose of this pull request?

Closes #186 

### What changes did you make? (overview)

Added `allowed_to?(:rule, obj, inline_reasons: true)` to merge reasons into the current reasons set.

### Is there anything you'd like reviewers to focus on?

PR checklist:

- [x] Tests included
- [x] Documentation updated
- [x] Changelog entry added
