### PR TITLE
Use kwargs in policy initializer API

### DIFF
--- a/lib/action_policy/behaviours/policy_for.rb
+++ b/lib/action_policy/behaviours/policy_for.rb
@@ -15,7 +15,7 @@ module ActionPolicy
           record,
           namespace:, context:, allow_nil:, default:, strict_namespace:
         )
-        policy_class&.new(record, **context)
+        policy_class&.new(record: record, **context)
       end
 
       def authorization_context

--- a/lib/action_policy/policy/authorization.rb
+++ b/lib/action_policy/policy/authorization.rb
@@ -43,8 +43,8 @@ module ActionPolicy
 
       attr_reader :authorization_context
 
-      def initialize(record = nil, **params)
-        super(record)
+      def initialize(record: nil, **params)
+        super(record: record)
 
         @authorization_context = {}
 

--- a/lib/action_policy/policy/core.rb
+++ b/lib/action_policy/policy/core.rb
@@ -74,12 +74,11 @@ module ActionPolicy
 
       attr_reader :record, :result
 
-      # NEXT_RELEASE: deprecate `record` arg, migrate to `record: nil`
-      def initialize(record = nil, *)
+      def initialize(record: nil, **params)
         @record = record
       end
 
-      # Returns a result of applying the specified rule (true of false).
+      # Returns a result of applying the specified rule (true or false).
       # Unlike simply calling a predicate rule (`policy.manage?`),
       # `apply` also calls pre-checks.
       def apply(rule)

--- a/lib/action_policy/rails/policy/instrumentation.rb
+++ b/lib/action_policy/rails/policy/instrumentation.rb
@@ -11,7 +11,7 @@ module ActionPolicy # :nodoc:
         INIT_EVENT_NAME = "action_policy.init"
         APPLY_EVENT_NAME = "action_policy.apply_rule"
 
-        def initialize(record = nil, **params)
+        def initialize(record: nil, **params)
           event = {policy: self.class.name}
           ActiveSupport::Notifications.instrument(INIT_EVENT_NAME, event) { super }
         end

--- a/lib/action_policy/rspec/dsl.rb
+++ b/lib/action_policy/rspec/dsl.rb
@@ -50,7 +50,7 @@ if defined?(::RSpec)
   ::RSpec.shared_context "action_policy:policy_context" do
     let(:record) { nil }
     let(:context) { {} }
-    let(:policy) { described_class.new(record, **context) }
+    let(:policy) { described_class.new(record: record, **context) }
   end
 
   ::RSpec.shared_context "action_policy:policy_rule_context" do |policy_rule, *args, method: "describe", block: nil|

--- a/lib/action_policy/rspec/pundit_syntax.rb
+++ b/lib/action_policy/rspec/pundit_syntax.rb
@@ -10,7 +10,7 @@ module ActionPolicy
         matcher :permit do |user, record|
           match do |policy|
             permissions.all? do |permission|
-              policy.new(record, user: user).apply(permission)
+              policy.new(record: record, user: user).apply(permission)
             end
           end
         end

--- a/test/action_policy/behaviours/memoized_test.rb
+++ b/test/action_policy/behaviours/memoized_test.rb
@@ -14,7 +14,7 @@ class TestMemoized < Minitest::Test
       end
     end
 
-    def initialize(record = nil, **params)
+    def initialize(record: nil, **params)
       super
       self.class.policies << self
     end

--- a/test/action_policy/behaviours/thread_memoized_test.rb
+++ b/test/action_policy/behaviours/thread_memoized_test.rb
@@ -16,7 +16,7 @@ class TestThreadMemoized < Minitest::Test
       end
     end
 
-    def initialize(record = nil, **params)
+    def initialize(record: nil, **params)
       super
       MUTEX.synchronize do
         self.class.policies << self

--- a/test/action_policy/policy/cache_test.rb
+++ b/test/action_policy/policy/cache_test.rb
@@ -93,7 +93,7 @@ class TestCache < Minitest::Test
   def test_cache
     user = CacheableUser.new("admin")
 
-    policy = TestPolicy.new guest, user: user
+    policy = TestPolicy.new record: guest, user: user
 
     assert policy.apply(:manage?)
     assert policy.apply(:manage?)
@@ -103,7 +103,7 @@ class TestCache < Minitest::Test
     assert_equal 1, TestPolicy.managed_count
     assert_equal 2, TestPolicy.shown_count
 
-    policy_2 = TestPolicy.new guest, user: user
+    policy_2 = TestPolicy.new record: guest, user: user
 
     assert policy_2.apply(:manage?)
     assert policy_2.apply(:show?)
@@ -115,14 +115,14 @@ class TestCache < Minitest::Test
   def test_custom_cache
     user = CacheableUser.new("guest")
 
-    policy = TestPolicy.new nil, user: user
+    policy = TestPolicy.new record: nil, user: user
 
     assert policy.apply(:create?)
     assert policy.apply(:create?)
 
     assert_equal 1, TestPolicy.custom_count
 
-    policy_2 = TestPolicy.new nil, user: user
+    policy_2 = TestPolicy.new record: nil, user: user
 
     assert policy_2.apply(:create?)
 
@@ -132,12 +132,12 @@ class TestCache < Minitest::Test
   def test_cache_with_reasons
     user = CacheableUser.new("guest")
 
-    policy = TestPolicy.new guest, user: user
+    policy = TestPolicy.new record: guest, user: user
 
     refute policy.apply(:save?)
     assert_equal({test: [:manage?]}, policy.result.reasons.details)
 
-    policy = TestPolicy.new guest, user: user
+    policy = TestPolicy.new record: guest, user: user
 
     refute policy.apply(:save?)
     assert_equal({test: [:manage?]}, policy.result.reasons.details)
@@ -149,13 +149,13 @@ class TestCache < Minitest::Test
   def test_cache_with_different_records
     user = CacheableUser.new("admin")
 
-    policy = TestPolicy.new guest, user: user
+    policy = TestPolicy.new record: guest, user: user
 
     assert policy.apply(:manage?)
 
     assert_equal 1, TestPolicy.managed_count
 
-    policy_2 = TestPolicy.new CacheableUser.new("guest_2"), user: user
+    policy_2 = TestPolicy.new record: CacheableUser.new("guest_2"), user: user
 
     assert policy_2.apply(:manage?)
     assert_equal 2, TestPolicy.managed_count
@@ -164,13 +164,13 @@ class TestCache < Minitest::Test
   def test_cache_with_different_contexts
     user = CacheableUser.new("admin")
 
-    policy = TestPolicy.new guest, user: user
+    policy = TestPolicy.new record: guest, user: user
 
     assert policy.apply(:manage?)
 
     assert_equal 1, TestPolicy.managed_count
 
-    policy_2 = TestPolicy.new guest, user: CacheableUser.new("admin_2")
+    policy_2 = TestPolicy.new record: guest, user: CacheableUser.new("admin_2")
 
     assert policy_2.apply(:manage?)
     assert_equal 2, TestPolicy.managed_count
@@ -179,7 +179,7 @@ class TestCache < Minitest::Test
   def test_with_multiple_contexts
     user = CacheableUser.new("admin")
 
-    policy = MultipleContextPolicy.new guest, user: user, account: "test"
+    policy = MultipleContextPolicy.new record: guest, user: user, account: "test"
 
     assert policy.apply(:manage?)
     assert policy.apply(:manage?)
@@ -189,7 +189,7 @@ class TestCache < Minitest::Test
     assert_equal 1, MultipleContextPolicy.managed_count
     assert_equal 1, MultipleContextPolicy.shown_count
 
-    policy_2 = MultipleContextPolicy.new guest, user: CacheableUser.new("admin"), account: :test
+    policy_2 = MultipleContextPolicy.new record: guest, user: CacheableUser.new("admin"), account: :test
 
     assert policy_2.apply(:manage?)
     assert policy_2.apply(:show?)
@@ -201,14 +201,14 @@ class TestCache < Minitest::Test
   def test_with_different_multiple_contexts
     user = CacheableUser.new("admin")
 
-    policy = MultipleContextPolicy.new guest, user: user, account: "test"
+    policy = MultipleContextPolicy.new record: guest, user: user, account: "test"
 
     assert policy.apply(:manage?)
     assert policy.apply(:manage?)
 
     assert_equal 1, MultipleContextPolicy.managed_count
 
-    policy_2 = MultipleContextPolicy.new guest, user: CacheableUser.new("admin"), account: "test_2"
+    policy_2 = MultipleContextPolicy.new record: guest, user: CacheableUser.new("admin"), account: "test_2"
 
     assert policy_2.apply(:manage?)
     assert_equal 2, MultipleContextPolicy.managed_count

--- a/test/action_policy/policy/cached_apply_test.rb
+++ b/test/action_policy/policy/cached_apply_test.rb
@@ -25,7 +25,7 @@ class TestCachedApply < Minitest::Test
   end
 
   def test_cache_truth
-    policy = TestPolicy.new true
+    policy = TestPolicy.new record: true
 
     assert policy.apply(:manage?)
     assert policy.apply(:manage?)
@@ -34,7 +34,7 @@ class TestCachedApply < Minitest::Test
   end
 
   def test_cache_falsey
-    policy = TestPolicy.new false
+    policy = TestPolicy.new record: false
 
     refute policy.apply(:manage?)
     refute policy.apply(:manage?)
@@ -43,7 +43,7 @@ class TestCachedApply < Minitest::Test
   end
 
   def test_cache_with_reasons
-    policy = TestPolicy.new false
+    policy = TestPolicy.new record: false
 
     refute policy.apply(:kill?)
     assert_equal({test: [:manage?]}, policy.result.reasons.details)

--- a/test/action_policy/policy/core_test.rb
+++ b/test/action_policy/policy/core_test.rb
@@ -23,7 +23,7 @@ end
 class TestPolicyCore < Minitest::Test
   def setup
     @record = {}
-    @policy = CoreTestPolicy.new @record
+    @policy = CoreTestPolicy.new record: @record
   end
 
   def test_apply

--- a/test/action_policy/policy/pre_check_test.rb
+++ b/test/action_policy/policy/pre_check_test.rb
@@ -54,27 +54,27 @@ class TestPreCheck < Minitest::Test
   attr_reader :guest, :admin
 
   def test_allow_pre_check
-    policy = TestPolicy.new false, user: admin
+    policy = TestPolicy.new record: false, user: admin
 
     assert policy.apply(:manage?)
 
-    policy2 = TestPolicy.new false, user: guest
+    policy2 = TestPolicy.new record: false, user: guest
 
     refute policy2.apply(:manage?)
   end
 
   def test_deny_pre_check
-    policy = TestPolicy.new false, user: guest
+    policy = TestPolicy.new record: false, user: guest
 
     assert policy.apply(:index?)
     refute policy.apply(:manage?)
 
-    policy2 = TestPolicy.new nil, user: guest
+    policy2 = TestPolicy.new record: nil, user: guest
 
     assert policy2.apply(:index?)
     refute policy2.apply(:manage?)
 
-    policy3 = TestPolicy.new nil, user: admin
+    policy3 = TestPolicy.new record: nil, user: admin
 
     assert policy3.apply(:index?)
     assert policy3.apply(:manage?)
@@ -91,13 +91,13 @@ class TestPreCheck < Minitest::Test
   end
 
   def test_skip_except_pre_check_with_only
-    policy = AdminTestPolicy.new false, user: admin
+    policy = AdminTestPolicy.new record: false, user: admin
 
     assert policy.apply(:index?)
     refute policy.apply(:manage?)
     assert policy.apply(:show?)
 
-    policy2 = AdminTestPolicy.new nil, user: guest
+    policy2 = AdminTestPolicy.new record: nil, user: guest
 
     assert policy2.apply(:index?)
     assert policy2.apply(:manage?)
@@ -105,13 +105,13 @@ class TestPreCheck < Minitest::Test
   end
 
   def test_skip_only_pre_check_with_except
-    policy = TestPolicy.new true, user: User.new("Neil")
+    policy = TestPolicy.new record: true, user: User.new("Neil")
 
     refute policy.apply(:index?)
     refute policy.apply(:new?)
     assert policy.apply(:manage?)
 
-    policy2 = AdminTestPolicy.new true, user: User.new("Neil")
+    policy2 = AdminTestPolicy.new record: true, user: User.new("Neil")
 
     assert policy2.apply(:index?)
     refute policy2.apply(:new?)
@@ -128,7 +128,7 @@ class TestPreCheck < Minitest::Test
   end
 
   def test_skip_pre_check_completely
-    policy = NoAdminTestPolicy.new false, user: admin
+    policy = NoAdminTestPolicy.new record: false, user: admin
 
     assert policy.apply(:index?)
     refute policy.apply(:manage?)
@@ -146,7 +146,7 @@ class TestPreCheck < Minitest::Test
   end
 
   def test_pre_check_with_reasons
-    policy = ReasonsTestPolicy.new true, user: User.new("Neil")
+    policy = ReasonsTestPolicy.new record: true, user: User.new("Neil")
 
     refute policy.apply(:index?)
 

--- a/test/action_policy/rails/cache_test.rb
+++ b/test/action_policy/rails/cache_test.rb
@@ -46,14 +46,14 @@ class TestRailsPolicyCache < Minitest::Test
   def test_cache_with_versioning
     user = AR::User.create!(role: "admin")
 
-    policy = UserPolicy.new guest, user: user
+    policy = UserPolicy.new record: guest, user: user
 
     assert policy.apply(:manage?)
     assert policy.apply(:manage?)
 
     assert_equal 1, UserPolicy.managed_count
 
-    policy_2 = UserPolicy.new guest, user: user
+    policy_2 = UserPolicy.new record: guest, user: user
 
     assert policy_2.apply(:manage?)
 
@@ -61,7 +61,7 @@ class TestRailsPolicyCache < Minitest::Test
 
     user.touch
 
-    policy_3 = UserPolicy.new guest, user: user
+    policy_3 = UserPolicy.new record: guest, user: user
 
     assert policy_3.apply(:manage?)
 
@@ -69,7 +69,7 @@ class TestRailsPolicyCache < Minitest::Test
 
     guest.touch
 
-    policy_4 = UserPolicy.new guest, user: user
+    policy_4 = UserPolicy.new record: guest, user: user
 
     assert policy_4.apply(:manage?)
 

--- a/test/action_policy/rails/instrumentation_test.rb
+++ b/test/action_policy/rails/instrumentation_test.rb
@@ -60,7 +60,7 @@ class TestRailsInstrumentation < Minitest::Test
   attr_reader :events
 
   def test_instrument_apply
-    policy = TestPolicy.new false
+    policy = TestPolicy.new record: false
 
     # drop init event
     events.shift
@@ -79,7 +79,7 @@ class TestRailsInstrumentation < Minitest::Test
   end
 
   def test_instrument_cached_apply
-    policy = TestPolicy.new true
+    policy = TestPolicy.new record: true
 
     # drop init event
     events.shift
@@ -148,7 +148,7 @@ class TestRailsInstrumentation < Minitest::Test
   end
 
   def test_instrument_initialize
-    TestPolicy.new true
+    TestPolicy.new record: true
     assert_equal 1, events.size
 
     event, data = events.shift

--- a/test/action_policy/rails/views_test.rb
+++ b/test/action_policy/rails/views_test.rb
@@ -59,7 +59,7 @@ class TestControllerViewsMemoization < ActionController::TestCase
       end
     end
 
-    def initialize(record = nil, **params)
+    def initialize(record: nil, **params)
       super
       self.class.policies << self
     end


### PR DESCRIPTION
From https://github.com/palkan/action_policy/issues/190

This commit changes the policy initializer API to take all kwargs instead of having
  an optional first `record` arg.