### PR TITLE
[189] | Add #be_an_alias_of rspec matcher

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -43,6 +43,23 @@ describe PostPolicy do
 end
 ```
 
+And we provide a `#be_an_alias_of` RSpec matcher for testing authorization rule aliases:
+
+```ruby
+describe PostPolicy do
+  let(:user) { build_stubbed(:user) }
+  let(:post) { build_stubbed(:post) }
+
+  let(:policy) { described_class.new(post, user: user) }
+
+  describe "#show?" do
+    it "is an alias of :index? authorization rule" do
+      expect(:show?).to be_an_alias_of(policy, :index?)
+    end
+  end
+end
+```
+
 ### RSpec DSL
 
 We also provide a simple RSpec DSL which aims to reduce the boilerplate when writing

--- a/lib/action_policy/rspec.rb
+++ b/lib/action_policy/rspec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
+require "action_policy/rspec/be_an_alias_of"
 require "action_policy/rspec/be_authorized_to"
 require "action_policy/rspec/have_authorized_scope"

--- a/lib/action_policy/rspec/be_an_alias_of.rb
+++ b/lib/action_policy/rspec/be_an_alias_of.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "action_policy/testing"
-require 'pry-byebug'
 
 module ActionPolicy
   module RSpec

--- a/lib/action_policy/rspec/be_an_alias_of.rb
+++ b/lib/action_policy/rspec/be_an_alias_of.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "action_policy/testing"
+require 'pry-byebug'
+
+module ActionPolicy
+  module RSpec
+    # Policy rule alias matcher `be_an_alias_of`.
+    #
+    # Verifies that for given policy a policy rule has an alias.
+    #
+    # Example:
+    #
+    #   # in policy specs
+    #   subject(:policy) { described_class.new(record, user: user) }
+    #
+    #   let(:user) { build_stubbed(:user) }
+    #   let(:record) { build_stubbed(:post) }
+    #
+    #   describe "#show?" do
+    #     it "is an alias of :index? policy rule" do
+    #       expect(:show?).to be_an_alias_of(policy, :index?)
+    #     end
+    #   end
+    #
+    #   # negated version
+    #   describe "#show?" do
+    #     it "is not an alias of :index? policy rule" do
+    #       expect(:show?).to_not be_an_alias_of(policy, :index?)
+    #     end
+    #   end
+    #
+    class BeAnAliasOf < ::RSpec::Matchers::BuiltIn::BaseMatcher
+      attr_reader :policy, :rule, :actual
+
+      def initialize(policy, rule)
+        @policy = policy
+        @rule = rule
+      end
+
+      def match(_expected, actual)
+        policy.resolve_rule(actual) == rule
+      end
+
+      def does_not_match?(actual)
+        @actual = actual
+        policy.resolve_rule(actual) != rule
+      end
+
+      def supports_block_expectations?() = false
+
+      def failure_message
+        "expected #{policy}##{actual} " \
+        "to be an alias of #{policy}##{rule}"
+      end
+
+      def failure_message_when_negated
+        "expected #{policy}##{actual} " \
+        "to not be an alias of #{policy}##{rule}"
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include(Module.new do
+    def be_an_alias_of(policy, rule)
+      ActionPolicy::RSpec::BeAnAliasOf.new(policy, rule)
+    end
+  end)
+end

--- a/spec/action_policy/rspec_spec.rb
+++ b/spec/action_policy/rspec_spec.rb
@@ -66,18 +66,18 @@ end
 describe "ActionPolicy RSpec matchers" do
   subject { TestService.new("guest") }
 
-  describe '#be_an_alias_of' do
+  describe "#be_an_alias_of" do
     let(:policy) { TestService::CustomPolicy.new(User.new("guest"), user: User.new("admin")) }
     let(:target) { :some_action? }
 
-    context 'when using positive matcher' do
-      context 'when provided rule is an alias to target policy rule' do
+    context "when using positive matcher" do
+      context "when provided rule is an alias to target policy rule" do
         specify do
           expect(:aliased_action?).to be_an_alias_of(policy, target)
         end
       end
 
-      context 'when provided rule is not an alias to target policy rule' do
+      context "when provided rule is not an alias to target policy rule" do
         specify do
           expect do
             expect(:bad_action?).to be_an_alias_of(policy, target)
@@ -86,14 +86,14 @@ describe "ActionPolicy RSpec matchers" do
       end
     end
 
-    context 'when using negative matcher' do
-      context 'when provided rule is not an alias to target policy rule' do
+    context "when using negative matcher" do
+      context "when provided rule is not an alias to target policy rule" do
         specify do
           expect(:bad_action?).to_not be_an_alias_of(policy, target)
         end
       end
 
-      context 'when provided rule is an alias to target policy rule' do
+      context "when provided rule is an alias to target policy rule" do
         specify do
           expect do
             expect(:aliased_action?).to_not be_an_alias_of(policy, target)
@@ -102,10 +102,10 @@ describe "ActionPolicy RSpec matchers" do
       end
     end
 
-    context 'matcher errors' do
+    context "matcher errors" do
       specify "block is not supported" do
         expect do
-          expect{ subject }.to be_an_alias_of('PolicyStub', 'PolicyRuleStub')
+          expect { subject }.to be_an_alias_of("PolicyStub", "PolicyRuleStub")
         end.to raise_error(/You must pass an argument rather than a block/)
       end
     end


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

### What is the purpose of this pull request?

Adds `#be_an_alias_of` RSpec matcher as proposed in #189

### What changes did you make? (overview)

I've added the `#be_an_alias_of` matcher, tests, and documentation for it. It works like this:

```ruby
describe '#show?' do
  it 'is an alias to #index? rule' do
    expect(:show?).to be_an_alias_of(policy, :index?)
  end
end
```

### Is there anything you'd like reviewers to focus on?

The changelog mentions only changes made within versions, and a future release will include this change. Therefore I did not add anything to the changelog. Not sure that it's OK.
I forbid block matches for this RSpec matcher - not sure if this is expected behavior.
Also, we could add some kind of helper for our `dsl`, but it might be confusing for developers, so maybe we should just add a matcher. I think adding alias matcher to `dsl` might have negative consequences for the clarity of action policy tests written with it.

PR checklist:

- [x] Tests included
- [x] Documentation updated
- [x] ~Changelog entry added~
