### PR TITLE
Policy lookup when with: is string or symbol

### DIFF
--- a/lib/action_policy/behaviours/policy_for.rb
+++ b/lib/action_policy/behaviours/policy_for.rb
@@ -11,11 +11,13 @@ module ActionPolicy
       def policy_for(record:, with: nil, namespace: authorization_namespace, context: nil, allow_nil: false, default: default_authorization_policy_class, strict_namespace: authorization_strict_namespace)
         context = context ? authorization_context.merge(context) : authorization_context
 
-        if with.is_a? String || with.is_a? Symbol
+        if with.is_a?(String) || with.is_a?(Symbol)
           record = with
           with = nil
         end
-        
+
+        byebug
+
         policy_class = with || ::ActionPolicy.lookup(
           record,
           namespace:, context:, allow_nil:, default:, strict_namespace:

--- a/lib/action_policy/behaviours/policy_for.rb
+++ b/lib/action_policy/behaviours/policy_for.rb
@@ -11,6 +11,11 @@ module ActionPolicy
       def policy_for(record:, with: nil, namespace: authorization_namespace, context: nil, allow_nil: false, default: default_authorization_policy_class, strict_namespace: authorization_strict_namespace)
         context = context ? authorization_context.merge(context) : authorization_context
 
+        if with.is_a? String || with.is_a? Symbol
+          record = with
+          with = nil
+        end
+        
         policy_class = with || ::ActionPolicy.lookup(
           record,
           namespace:, context:, allow_nil:, default:, strict_namespace:

--- a/lib/action_policy/behaviours/policy_for.rb
+++ b/lib/action_policy/behaviours/policy_for.rb
@@ -16,8 +16,6 @@ module ActionPolicy
           with = nil
         end
 
-        byebug
-
         policy_class = with || ::ActionPolicy.lookup(
           record,
           namespace:, context:, allow_nil:, default:, strict_namespace:


### PR DESCRIPTION
In reference to this issue: https://github.com/palkan/action_policy/issues/203

Changes `#policy_for` to lookup the policy when `with:` is passed as a string or symbol. Helpful when we want to use a custom policy but also respect a dynamic `authoriization_namespace`.