### PR TITLE
Add authorization callbacks to Rails controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Add `before_authorize`, `after_authorize` and `around_authorize` callbacks. ([@percysnoodle][])
+
 ## 0.6.3 (2022-08-16)
 
 - Fix regression for [#179](https://github.com/palkan/action_policy/issues/179). ([@palkan][])

--- a/docs/rails.md
+++ b/docs/rails.md
@@ -77,6 +77,28 @@ class PostsController < ApplicationController
 end
 ```
 
+### Callbacks
+
+You can add and skip callbacks which are called before, after and around authorization:
+
+```ruby
+class PostsController < ApplicationController
+  before_action :authorize!
+  before_authorize :set_current_user, only: :index
+  
+  def index
+  end
+  
+  private
+  
+  attr_reader :current_user
+  
+  def set_current_user
+    @current_user = User.find(params[:id])
+  end
+end
+```
+
 ### Usage with `API` and `Metal` controllers
 
 Action Policy is only included into `ActionController::Base`. If you want to use it with other base Rails controllers, you have to include it manually:


### PR DESCRIPTION
I've been working on application which uses `before_action` callbacks in our ApplicationController, first to set the current context, and then to authorize the action using ActionPolicy:

```
before_action :set_current_context
before_action :authorize!
```

One policy requires an extra piece of information which depends on the current context.  If we use `before_action` to set it, it gets set after `authorize!` is called; but if we use `prepend_before_action` it gets set before the current context is available.  Either way, it doesn't work.

So, this PR adds callbacks to the `authorize!` method, so we can set it in a `before_authorize` callback, which will run before the policy is applied but after the current context is available.

To match the behaviour of `before_action` etc.. this is implemented using ActionController's `_insert_callbacks` method. The underscore tells me this isn't part of the public API, but it has been stable since Rails 3 so it feels acceptable to use.

PR checklist:

- [x] Tests included
- [x] Documentation updated
- [x] Changelog entry added
