### PR TITLE
Fix testing docs (stubbed models cannot access DB)

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -162,13 +162,13 @@ describe PostPolicy do
     end
 
     context "as manager" do
-      before { user.update!(role: :manager) }
+      before { user.role = :manager }
 
       it { is_expected.to eq(%w[A B]) }
     end
 
     context "as banned user" do
-      before { user.update!(banned: true) }
+      before { user.banned = true }
 
       it { is_expected.to be_empty }
     end


### PR DESCRIPTION
When running the code sample as is, I get this error:

```
     Failure/Error: before { user.update!(role: :user) }
     
     RuntimeError:
       stubbed models are not allowed to access the database - User#update!({:role=>:user})
```

So instead of updating the stubbed user, I just change the attribute value.