### PR TITLE
Docs: rename my_data > data

### DIFF
--- a/docs/scoping.md
+++ b/docs/scoping.md
@@ -48,9 +48,9 @@ class PostPolicy < ApplicationPolicy
     relation.where(user: user)
   end
 
-  # define a scope of `my_data` type,
+  # define a scope of `data` type,
   # which acts on hashes
-  scope_for :my_data do |data|
+  scope_for :data do |data|
     next data if user.admin?
     data.delete_if { |k, _| SENSITIVE_KEYS.include?(k) }
   end


### PR DESCRIPTION
I can't find any other occurrence of `my_data` in the repository, whereas the specs use `scope_for :data` (for instance [here](https://github.com/palkan/action_policy/blob/d8c76db9a220138dfbf4b809c17b063e157081a9/test/action_policy/policy/scoping_test.rb#L13)).

I guess it's a good idea to make it consistent.

PR checklist:

- [x] Documentation updated
