### PR TITLE
Replace File.exists?

### DIFF
--- a/lib/generators/rspec/templates/policy_spec.rb.tt
+++ b/lib/generators/rspec/templates/policy_spec.rb.tt
@@ -1,4 +1,4 @@
-require "<%= File.exists?('spec/rails_helper.rb') ? 'rails_helper' : 'spec_helper' %>"
+require "<%= File.exist?('spec/rails_helper.rb') ? 'rails_helper' : 'spec_helper' %>"
 
 RSpec.describe <%= class_name %>Policy, type: :policy do
   # See https://actionpolicy.evilmartians.io/#/testing?id=rspec-dsl


### PR DESCRIPTION
`File.exists?` has been deprecated and removed in Ruby 3.2. As a result, rails generator fails:

```
/Users/u/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/action_policy-0.6.4/lib/generators/rspec/templates/policy_spec.rb.tt:1:in `template': undefined method `exists?' for File:Class (NoMethodError)

@output_buffer = ''.dup; @output_buffer.concat "require \"".freeze; @output_buffer.concat(( File.exists?('spec/rails_helper.rb') ? 'rails_helper' : 'spec_helper' ).to_s); @output_buffer.concat "\"\n\nRSpec.describe ".freeze
                                                                                                ^^^^^^^^
Did you mean?  exist?
```

https://bugs.ruby-lang.org/issues/17391
