### PR TITLE
Improving the alias documentation

### DIFF
--- a/docs/aliases.md
+++ b/docs/aliases.md
@@ -74,14 +74,13 @@ Here's the order in which aliases and concrete rule methods are resolved in rega
   * When aliases are defined on the subclass they will overwrite matching aliases on the superclass.
 3. If there is a concrete rule method on the superclass, then this is called, else
 4. If there is a default rule defined, then this is called, else
-5. `ActionPolicy::UnknownRule` is raised.
+5. If the default rule is unaltered, then the `manage?` rule is called
+6. If the default rule is set to `nil`, `ActionPolicy::UnknownRule` is raised.
 
 Here's an example with the expected results:
 
 ```ruby
 class SuperPolicy < ApplicationPolicy
-  default_rule :manage?
-
   alias_rule :update?, :destroy?, :create?, to: :edit?
 
   def manage?
@@ -112,7 +111,7 @@ Authorizing against the SuperPolicy:
 * `manage?` will resolve to `manage?`
 * `edit?` will resolve to `edit?`
 * `index?` will resolve to `index?`
-* `something?` will resolve to `manage?`
+* `something?` will resolve to the `default_rule`: `manage?`
 
 Authorizing against the SubPolicy:
 


### PR DESCRIPTION
We searched a while to figure out why spelling mistakes caused an `Unauthorized` error instead of an `UnknownRule` error.

It took us very long to realize that the `default_rule` has a default value of `manage?`, and that this rule by default also returns `false`. 

This change improves the documentation somewhat IMO.

Though I wonder if the `default_rule` needs a default value at all. Both actions and rules are usually not dynamic. So any mismatch is a code issue and not an authorization issue. Thus I think that raising an `UnknownRule` makes more sense and it makes debugging easier. 

For anyone who does want a fallback to `manage?`, when following the usage guide in the readme, it's only a single line of code. But at least it's a conscious decision that way.

<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->


<!--
  Otherwise, describe the changes: 

### What is the purpose of this pull request?

### What changes did you make? (overview)

### Is there anything you'd like reviewers to focus on?

-->

PR checklist:

- [ ] Tests included
- [ ] Documentation updated
- [ ] Changelog entry added
