### PR TITLE
feat: Add --parent to policy generator to specify parent class of Policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## master
 
+- Add `--parent` option for policy generator ([@matsales28][])
+
+Example:
+
+`bin/rails g action_policy:policy user --parent=base_policy` generates:
+
+```ruby
+class UserPolicy < BasePolicy
+# ...
+end
+```
+
 ## 0.6.5 (2023-02-16)
 
 - Fix generated policies' outdated Ruby API (to work with Ruby 3.2).

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ end
 ```
 
 This may be done with `rails generate action_policy:policy Post` generator.
+You can also use `rails generate action_policy:policy Post --parent=BasePolicy` to make the generated policy inherits
+from `BasePolicy`.
 
 Now you can easily add authorization to your Rails\* controller:
 

--- a/docs/rails.md
+++ b/docs/rails.md
@@ -12,6 +12,7 @@ Action Policy provides a couple of useful Rails generators:
 
 - `rails g action_policy:install` — adds `app/policies/application_policy.rb` file
 - `rails g action_policy:policy MODEL_NAME` — adds a policy file and a policy test file for a given model (also creates an `application_policy.rb` if it's missing)
+- `rails g action_policy:policy MODEL_NAME --parent=base_policy` — adds a policy file that inherits from `BasePolicy`, and a policy test file for a given model (also creates an `application_policy.rb` if it's missing)
 
 ## Controllers integration
 

--- a/lib/generators/action_policy/policy/USAGE
+++ b/lib/generators/action_policy/policy/USAGE
@@ -2,7 +2,14 @@ Description:
     Generates a policy for a model with the given name.
 
 Example:
-    rails generate action_policy:policy user
+    rails generate action_policy:policy user --parent=base_policy
 
     This will create:
         app/policies/user_policy.rb
+
+	```ruby
+	class UserPolicy < BasePolicy
+	  # ...
+	end
+	```
+

--- a/lib/generators/action_policy/policy/policy_generator.rb
+++ b/lib/generators/action_policy/policy/policy_generator.rb
@@ -7,6 +7,8 @@ module ActionPolicy
     class PolicyGenerator < ::Rails::Generators::NamedBase
       source_root File.expand_path("templates", __dir__)
 
+      class_option :parent, type: :string, desc: "The parent class for the generated policy"
+
       def run_install_if_needed
         in_root do
           return if File.exist?("app/policies/application_policy.rb")
@@ -20,6 +22,16 @@ module ActionPolicy
       end
 
       hook_for :test_framework
+
+      private
+
+      def parent_class_name
+        parent || "ApplicationPolicy"
+      end
+
+      def parent
+        options[:parent]
+      end
     end
   end
 end

--- a/lib/generators/action_policy/policy/templates/policy.rb.tt
+++ b/lib/generators/action_policy/policy/templates/policy.rb.tt
@@ -1,5 +1,5 @@
 <% module_namespacing do -%>
-class <%= class_name %>Policy < ApplicationPolicy
+class <%= class_name %>Policy < <%= parent_class_name.classify %>
   # See https://actionpolicy.evilmartians.io/#/writing_policies
   #
   # def index?

--- a/spec/generators/policy_generator_spec.rb
+++ b/spec/generators/policy_generator_spec.rb
@@ -24,5 +24,14 @@ describe ActionPolicy::Generators::PolicyGenerator, type: :generator do
       is_expected.to exist
       is_expected.to contain(/class UserPolicy < ApplicationPolicy/)
     end
+
+    context "when using the parent option" do
+      let(:args) { ["user", "--parent", "base_policy"] }
+
+      specify do
+        is_expected.to exist
+        is_expected.to contain(/class UserPolicy < BasePolicy/)
+      end
+    end
   end
 end


### PR DESCRIPTION
Implements #239

This commit intends to allow using the `--parent` option on the policy generator to specify the parent class of the generated policy.

You can use `--parent=base_policy` or `--parent=BasePolicy` as we call `classify` on the given value for the parent option.

Example:

`bin/rails g action_policy:policy user --parent=base_policy` generates:

```ruby
class UserPolicy < BasePolicy
  ...
end
```


PR checklist:

- [x] Tests included
- [x] Documentation updated
- [x] Changelog entry added
