### PR TITLE
Add Graphiti integration to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Composable. Extensible. Performant.
 ## Integrations
 
 - GraphQL Ruby ([`action_policy-graphql`](https://github.com/palkan/action_policy-graphql))
+- Graphiti (JSON:API) ([`action_policy-graphiti`](https://github.com/shrimple-tech/action_policy-graphiti))
 
 ## Installation
 


### PR DESCRIPTION
Hi, this is just a small PR to include our [integration](https://github.com/shrimple-tech/action_policy-graphiti) of Action Policy with JSON:API implementation ([Graphiti](https://github.com/graphiti-api/graphiti)) into the readme.
