### PR TITLE
Added `with_context` qualifier to `have_authorized_scope` matcher

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -323,6 +323,10 @@ class UsersController < ApplicationController
   def index
     @user = authorized(User.all)
   end
+
+  def favorite
+    authorized_scope(User.all, context: {favorite: true})
+  end
 end
 ```
 
@@ -406,6 +410,14 @@ expect { subject }.to have_authorized_scope(:scope)
   .with_target { |target|
     expect(target).to eq(User.all)
   }
+```
+
+Also can use the `with_context` options:
+
+```ruby
+expect { get :favorite }.to have_authorized_scope(:scope)
+  .with_scope_options(matching(with_deleted: a_falsey_value))
+  .with_context(favorite: true)
 ```
 
 ## Testing views

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -324,8 +324,9 @@ class UsersController < ApplicationController
     @user = authorized(User.all)
   end
 
-  def favorite
-    authorized_scope(User.all, context: {favorite: true})
+  def for_user
+    user = User.find(params[:id])
+    authorized_scope(User.all, context: {user:})
   end
 end
 ```
@@ -415,9 +416,9 @@ expect { subject }.to have_authorized_scope(:scope)
 Also can use the `with_context` options:
 
 ```ruby
-expect { get :favorite }.to have_authorized_scope(:scope)
+expect { get :for_user, params: {id: user.id} }.to have_authorized_scope(:scope)
   .with_scope_options(matching(with_deleted: a_falsey_value))
-  .with_context(favorite: true)
+  .with_context(a_hash_including(user:))
 ```
 
 ## Testing views

--- a/lib/action_policy/rspec/have_authorized_scope.rb
+++ b/lib/action_policy/rspec/have_authorized_scope.rb
@@ -27,7 +27,6 @@ module ActionPolicy
         @type = type
         @name = :default
         @scope_options = nil
-        @context = {}
       end
 
       def with(policy)
@@ -105,7 +104,7 @@ module ActionPolicy
       end
 
       def context_message
-        context.empty? ? "without context" : "with context: #{context}"
+        context.blank? ? "without context" : "with context: #{context}"
       end
 
       def actual_scopes_message

--- a/lib/action_policy/test_helper.rb
+++ b/lib/action_policy/test_helper.rb
@@ -82,7 +82,7 @@ module ActionPolicy
     #     end
     #   end
     #
-    def assert_have_authorized_scope(type:, with:, as: :default, scope_options: nil)
+    def assert_have_authorized_scope(type:, with:, as: :default, scope_options: nil, context: {})
       raise ArgumentError, "Block is required" unless block_given?
 
       policy = with
@@ -97,10 +97,13 @@ module ActionPolicy
         "without scope options"
       end
 
+      context_message = context.empty? ? "without context" : "with context: #{context}"
+
       assert(
-        actual_scopes.any? { |scope| scope.matches?(policy, type, as, scope_options) },
+        actual_scopes.any? { |scope| scope.matches?(policy, type, as, scope_options, context) },
         "Expected a scoping named :#{as} for :#{type} type " \
         "#{scope_options_message} " \
+        "and #{context_message} " \
         "from #{policy} to have been applied, " \
         "but no such scoping has been made.\n" \
         "Registered scopings: " \

--- a/lib/action_policy/testing.rb
+++ b/lib/action_policy/testing.rb
@@ -34,7 +34,7 @@ module ActionPolicy
       end
 
       class Scoping # :nodoc:
-        attr_reader :policy, :target, :type, :name, :scope_options
+        attr_reader :policy, :target, :type, :name, :scope_options, :context
 
         def initialize(policy, target, type, name, scope_options)
           @policy = policy
@@ -42,13 +42,15 @@ module ActionPolicy
           @type = type
           @name = name
           @scope_options = scope_options
+          @context = policy.authorization_context
         end
 
-        def matches?(policy_class, actual_type, actual_name, actual_scope_options)
+        def matches?(policy_class, actual_type, actual_name, actual_scope_options, actual_context)
           policy_class == policy.class &&
             type == actual_type &&
             name == actual_name &&
-            actual_scope_options === scope_options
+            actual_scope_options === scope_options &&
+            actual_context.all? { |key, value| context[key] == value }
         end
 
         def inspect


### PR DESCRIPTION
Hi @palkan. I added `with_context` qualifier to `have_authorized_scope` matcher
Discussed in https://github.com/palkan/action_policy/issues/258

PR checklist:

- [x] Tests included
- [x] Documentation updated
