### PR TITLE
Allow to deny! with details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Allow to `deny!` with details. ([@inkstak][])
+
 ## 0.7.1 (2024-07-25)
 
 - Support passing scope options to callable scope objects. ([@palkan][])

--- a/docs/reasons.md
+++ b/docs/reasons.md
@@ -117,6 +117,18 @@ end
 p ex.result.reasons.details #=> { stage: [{show?: {title: "Onboarding"}] }
 ```
 
+You can provide details when calling `deny!`:
+
+```ruby
+class StagePolicy < ApplicationPolicy
+  def show?
+    deny!(:archived, since: record.archived_duration) if record.archived?
+  end
+end
+
+p ex.result.reasons.details #=> { stage: [{archived: {since:"2 days"}] }
+```
+
 **NOTE**: when using detailed reasons, the `details` array contains as the last element
 a hash with ALL details reasons for the policy (in a form of `<rule> => <details>`).
 

--- a/lib/action_policy/policy/reasons.rb
+++ b/lib/action_policy/policy/reasons.rb
@@ -16,7 +16,7 @@ module ActionPolicy
         policy_class = policy_or_class.is_a?(Module) ? policy_or_class : policy_or_class.class
         reasons[policy_class] ||= []
 
-        if details.nil?
+        if details.nil? || details.empty?
           add_non_detailed_reason reasons[policy_class], rule
         else
           add_detailed_reason reasons[policy_class], with_details(rule, details)
@@ -219,8 +219,8 @@ module ActionPolicy
         res.success?
       end
 
-      def deny!(reason = nil)
-        result&.reasons&.add(self, reason) if reason
+      def deny!(reason = nil, **details)
+        result&.reasons&.add(self, reason, details) if reason
         super()
       end
     end

--- a/test/action_policy/policy/reasons_test.rb
+++ b/test/action_policy/policy/reasons_test.rb
@@ -74,6 +74,10 @@ class TestComplexFailuresPolicy < Minitest::Test
       deny!(:cloning_humans_is_not_allowed)
     end
 
+    def confirmable?
+      deny!(:not_a_guest, username: user.name) if user.name != "guest"
+    end
+
     def copyable?
       check?(:non_guest)
     end
@@ -143,6 +147,18 @@ class TestComplexFailuresPolicy < Minitest::Test
 
     assert_equal({
       complex: [:no_singing_today]
+    }, details)
+  end
+
+  def test_deny_with_details
+    policy = ComplexFailuresTestPolicy.new user: User.new("admin")
+
+    refute policy.apply(:confirmable?)
+
+    details = policy.result.reasons.details
+
+    assert_equal({
+      confirmable?: {username: "admin"}
     }, details)
   end
 


### PR DESCRIPTION
### What is the purpose of this pull request?

It allows to add details when using `deny!` 

```ruby
class PostPolicy < ApplicationPolicy
   def show?
    deny!(:archived, since: record.archived_duration) if record.archived?
  end
end

p ex.result.reasons.details #=> { post: [{archived: {since:"2 days"}] }
```

### What changes did you make? (overview)

I've added keyword arguments to `deny!` to pass details.
The method keep working without them.

### PR checklist:

- [x] Tests included
- [x] Documentation updated
- [x] Changelog entry added
