### PR TITLE
Enable 'allowance_to' as helper method by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Enable `allowance_to` as a helper method by default ([@stephannv][])
+
 ## 0.7.3 (2024-12-18)
 
 - Fix keeping the result object in concurrent (Fiber-ed) execution environments. ([@palkan][])

--- a/lib/action_policy/rails/controller.rb
+++ b/lib/action_policy/rails/controller.rb
@@ -26,6 +26,7 @@ module ActionPolicy
       if respond_to?(:helper_method)
         helper_method :allowed_to?
         helper_method :authorized_scope
+        helper_method :allowance_to
       end
 
       attr_writer :authorize_count

--- a/test/action_policy/rails/views/users/index.html.erb
+++ b/test/action_policy/rails/views/users/index.html.erb
@@ -4,3 +4,6 @@
 <% if allowed_to?(:create?) %>
   <button>Create User</button>
 <% end %>
+
+<% result = allowance_to(:create?, with: UserPolicy) %>
+<%= result.rule %> - <%= result.value %>

--- a/test/action_policy/rails/views_test.rb
+++ b/test/action_policy/rails/views_test.rb
@@ -36,6 +36,7 @@ class TestViewsIntegration < ActionController::TestCase
     assert_includes response.body, "guest (editable)"
     assert_includes response.body, "admin (read-only)"
     assert_includes response.body, "Create User"
+    assert_includes response.body, "create? - true"
   end
 
   def test_index_as_guest
@@ -44,6 +45,7 @@ class TestViewsIntegration < ActionController::TestCase
     assert_includes response.body, "guest (read-only)"
     refute_includes response.body, "admin"
     refute_includes response.body, "Create User"
+    assert_includes response.body, "create? - false"
   end
 end
 


### PR DESCRIPTION
### What is the purpose of this pull request?
Enable the allowance_to method as a default helper method.

We use `allowance_to` to display disabled buttons with helpful messages, like "You don't have edit permission" or "Cannot edit archived documents". While adding `helper_method :allowance_to` to `ApplicationController` works, it breaks component/view tests because `ActionView::TestCase::TestController` (which includes `ActionPolicy::Controller`) doesn't expose this helper.

To fix this, we had to manually reopen the TestController class:
```ruby
class ActionView::TestCase::TestController
  helper_method :allowance_to
end
```
It would be helpful if `allowance_to` was a default helper to simplify usage and avoid such issues.

### What changes did you make? (overview)
On `ActionPolicy::Controller` I added `helper_method :allowance_to` along with `allowed_to?` and `:authorized_scope` methods. Added some tests (I couldn't think anything better to write on HTML).

### Is there anything you'd like reviewers to focus on?
No.

PR checklist:

- [x] Tests included
- [ ] Documentation updated (I didn't find an ideal place to add this change)
- [x] Changelog entry added
