### PR TITLE
Allow the `:through` option of `authorize` to be passed a proc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Enable `allowance_to` as a helper method by default ([@stephannv][])
 
+- Allow the `:through` option of `authorize` to be passed a proc ([@brendon][])
+
 ## 0.7.3 (2024-12-18)
 
 - Fix keeping the result object in concurrent (Fiber-ed) execution environments. ([@palkan][])

--- a/docs/authorization_context.md
+++ b/docs/authorization_context.md
@@ -48,6 +48,9 @@ class ApplicationController < ActionController::Base
   # get the required context object
   # (equals to the context name itself by default, i.e. `account`)
   authorize :account, through: :current_account
+
+  # `through` can also be passed a proc:
+  authorize :user, through: -> { Current.user }
 end
 ```
 

--- a/docs/rails.md
+++ b/docs/rails.md
@@ -26,6 +26,14 @@ class ApplicationController < ActionController::Base
 end
 ```
 
+You can also pass a proc to `:through`. This is useful if you're using `ActiveSupport::CurrentAttributes`:
+
+```ruby
+class ApplicationController < ActionController::Base
+  authorize :user, through: -> { Current.user }
+end
+```
+
 **NOTE:** The `controller_authorize_current_user` setting only affects the way authorization context is built in controllers but does not affect policy classes configuration. If you inherit from `ActionPolicy::Base`, you will still have the `user` required as an authorization context. Add `authorize :user, optional: true` to your base policy class to make it optional or use a [custom base class](custom_policy.md).
 
 > Read more about [authorization context](authorization_context.md).

--- a/lib/action_policy/behaviour.rb
+++ b/lib/action_policy/behaviour.rb
@@ -64,8 +64,8 @@ module ActionPolicy
 
     private def build_authorization_context
       self.class.authorization_targets
-        .each_with_object({}) do |(key, meth), obj|
-        obj[key] = send(meth)
+        .each_with_object({}) do |(key, method_or_proc), obj|
+        obj[key] = method_or_proc.is_a?(Proc) ? method_or_proc.call : send(method_or_proc)
       end
     end
 
@@ -105,8 +105,8 @@ module ActionPolicy
       #     authorize :user
       #   end
       def authorize(key, through: nil)
-        meth = through || key
-        authorization_targets[key] = meth
+        method_or_proc = through || key
+        authorization_targets[key] = method_or_proc
       end
 
       def authorization_targets

--- a/test/action_policy/rails/controllers_test.rb
+++ b/test/action_policy/rails/controllers_test.rb
@@ -306,3 +306,21 @@ class TestAnonymousControllerIntegration < ActionController::TestCase
     controller_class.action(:index).call(env)
   end
 end
+
+class TestProcCurrentUserControllerIntegration < ActionController::TestCase
+  class UsersController < ActionController::Base
+    authorize :user, through: -> { User.new({user: "guest"}) }
+
+    def index
+      authorize!
+      render plain: "OK"
+    end
+  end
+
+  tests UsersController
+
+  def test_index
+    get :index
+    assert_equal "OK", response.body
+  end
+end


### PR DESCRIPTION
Closes #291

### What is the purpose of this pull request?
Allows one to provide a proc to `authorize`'s `:through` option.

### What changes did you make? (overview)
Extended `build_authorization_context` to cope with a proc being passed in.

### Is there anything you'd like reviewers to focus on?
No.

PR checklist:

- [x] Tests included
- [x] Documentation updated
- [x] Changelog entry added
